### PR TITLE
Configuration changes

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -20,6 +20,24 @@ setenv FOO=bar
 import ./extra_options.cfg
 ```
 
+Property values can use earlier defined properties as variables within their value with a simple percentage syntax. Example:
+
+```bash
+# Set some properties
+appname=MyApplication
+version_major=1
+version_minor=3
+# Use already defined properties within other properties
+version_string=%{appname} %{version_major}.%{version_minor}
+```
+This will also work when reassign a the value of an already existing property. Example
+```bash
+path=/bin;/usr/bin;/usr/local/bin
+# prepend something to path
+path=/home/myuser/bin;%{path}
+```
+
+
 Extending the available configuration properties is done by adding modules to Gaudi::Configuration::SystemModules (for more details check [EXTENDING](EXTENDING.md))
 
 ### Precedence order

--- a/lib/gaudi/helpers/configuration.rb
+++ b/lib/gaudi/helpers/configuration.rb
@@ -175,7 +175,7 @@ module Gaudi
               elsif /^import\s+(?<path>.*)/ =~ l
                 cfg.merge!(import_config(path,cfg_dir))
               elsif /^(?<key>.*?)\s*=\s*(?<v>.*)/ =~ l
-                cfg[key]=handle_key(key,v,cfg_dir,list_keys,path_keys)
+                cfg[key]=handle_key(key,v,cfg_dir,list_keys,path_keys,cfg)
               else
                 raise GaudiConfigurationError,"Configuration syntax error in #{filename}:\n'#{l}'"
               end
@@ -203,8 +203,11 @@ module Gaudi
       #in the format we want to have.
       #
       #This means keys in list_keys come back as an Array, keys in path_keys come back as full paths
-      def handle_key key,value,cfg_dir,list_keys,path_keys
+      def handle_key key,value,cfg_dir,list_keys,path_keys,cfg
         final_value=value
+        # replace %{symbol} with values from already existing config values
+        final_value=final_value % Hash[cfg.map{|k,v| [k.to_sym,v]}] if final_value.include? "%{"
+
         if list_keys.include?(key) && path_keys.include?(key)
           final_value=Rake::FileList[*(value.gsub(/\s*,\s*/,',').split(',').uniq.map{|d| absolute_path(d.strip,cfg_dir)})]
         elsif list_keys.include?(key)

--- a/lib/gaudi/helpers/configuration.rb
+++ b/lib/gaudi/helpers/configuration.rb
@@ -11,7 +11,7 @@ module Gaudi
       cfg_file=File.expand_path()
       ENV['GAUDI_CONFIG']=cfg_file
       puts "Reading main configuration from \n\t#{cfg_file}"
-      system_config=SystemConfiguration.new(cfg_file)
+      system_config=SystemConfiguration.new(cfg_file)s
       return system_config
     else
       raise "No configuration file (GAUDI_CONFIG is empty)"
@@ -48,13 +48,15 @@ module Gaudi
     def self.switch_platform_configuration configuration_file,system_config,platform
       if block_given?
         begin
+          puts "Switching platform configuration for #{platform} to #{configuration_file}"
           current_config=system_config.platform_config(platform)
-          new_cfg=system_config.read_configuration(configuration_file,[],[])
-          system_config.set_platform_config(new_cfg,platform)
+          new_cfg_data=system_config.read_configuration(configuration_file,*system_config.keys)
+          system_config.set_platform_config(PlatformConfiguration.new(platform,new_cfg_data),platform)
           yield
         rescue
           raise
         ensure
+          puts "Switching back platform configuration for #{platform}"
           system_config.set_platform_config(current_config,platform)
         end
       end

--- a/lib/gaudi/helpers/configuration.rb
+++ b/lib/gaudi/helpers/configuration.rb
@@ -11,7 +11,7 @@ module Gaudi
       cfg_file=File.expand_path()
       ENV['GAUDI_CONFIG']=cfg_file
       puts "Reading main configuration from \n\t#{cfg_file}"
-      system_config=SystemConfiguration.new(cfg_file)s
+      system_config=SystemConfiguration.new(cfg_file)
       return system_config
     else
       raise "No configuration file (GAUDI_CONFIG is empty)"

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -28,6 +28,18 @@ class TestLoader < MiniTest::Unit::TestCase
     assert(!cfg.config.empty?, "Configuration should not be empty")
     assert_equal('bar', cfg.config['foo'])
   end
+  def test_property_reference
+    config=mock_configuration('system.cfg',['foo=bar','bar=%{foo}'])
+    cfg=Gaudi::Configuration::Loader.new(config)
+    assert(!cfg.config.empty?, "Configuration should not be empty")
+    assert_equal('bar', cfg.config['foo'])
+  end
+  def test_property_self_reference
+    config=mock_configuration('system.cfg',['foo=bar','foo=%{foo}*%{foo}'])
+    cfg=Gaudi::Configuration::Loader.new(config)
+    assert(!cfg.config.empty?, "Configuration should not be empty")
+    assert_equal('bar*bar', cfg.config['foo'])
+  end
   def test_environment
     config=mock_configuration('system.cfg',['setenv GAUDI = brilliant builder'])
     Gaudi::Configuration::Loader.new(config)
@@ -168,6 +180,12 @@ class TestBuildConfiguration < MiniTest::Unit::TestCase
     assert_equal(['foo.lib','bar.lib'],cfg.libs(system_cfg,'gcc'))
   end
 
+  def test_property_reference
+    config=mock_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','compiler_options= -DMODULE=%{prefix}'])
+    cfg=Gaudi::Configuration::BuildConfiguration.load([config])
+    assert_equal('-DMODULE=TST',cfg.option('compiler_options'))
+  end
+  
   def test_load
     config=mock_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','libs= foo.lib,bar.lib'])
     assert_raises(GaudiConfigurationError) { Gaudi::Configuration::BuildConfiguration.load([])}


### PR DESCRIPTION
Add variable substitution inside configuration values and 
fix switch_platform_configuration method.

Earlier defined configuration keys in a configuration file can now
be used as a variable inside following configuration values. Example: 
`major_version=1`
`minor_version=2`
`version_string=%{major_version}.%{minor_version}`