### PR TITLE
Modules concept

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,6 @@
 #0.12.0
  * Auto-generated build rules per target platform (makes running off-the-shelf a little bit easier)
+* Modules concept allows us to place code in directories other than custom
 
 #0.11.0
  * Allow multiple source subdirectories per platform configuration

--- a/README.md
+++ b/README.md
@@ -1,43 +1,43 @@
 # Gaudi - A Builder [![Build Status](https://travis-ci.org/damphyr/gaudi.png)](https://travis-ci.org/damphyr/gaudi) [![Coverage Status](https://coveralls.io/repos/damphyr/gaudi/badge.png)](https://coveralls.io/r/damphyr/gaudi) [![Code Climate](https://codeclimate.com/github/damphyr/gaudi.png)](https://codeclimate.com/github/damphyr/gaudi) [![doc status](http://inch-ci.org/github/damphyr/gaudi.svg?branch=master)](http://inch-ci.org/github/damphyr/gaudi)
 
-tl:dr; Go to the [documentation](http://www.rubydoc.info/github/damphyr/gaudi/master/index) 
+tl:dr; Go to the [documentation](http://www.rubydoc.info/github/damphyr/gaudi/master/index)
 
-This is not a gem<sup>1</sup> nor is it a library. It's more like a bootstrap for creating a build system for C or C++ based projects using rake.
+This is not a gem<sup>1</sup> nor is it a library. It's more like a bootstrap for a build system for C or C++ based projects using rake.
 
-A couple of guidelines, a bit of supporting code, a lot of assumptions and conventions with fill-in-the-blanks space for creating a works-for-me build system.  
+A couple of guidelines, a bit of supporting code, a lot of assumptions and conventions with fill-in-the-blanks space for creating a works-for-me build system.
 You're lucky I didn't call it yabsir (Yet Another Build System In Ruby)
 
 <sup>1</sup>There is a gaudi gem. It's purpose is to help set up and maintain a Gaudi installation.
-
-## Gaudi?
-
-Well, if you know who [Gaudi](http://en.wikipedia.org/wiki/Antoni_Gaud%C3%AD) was you should concentrate on the fact that he rarely produced detailed plans of his works, he created models. 
-
-Gaudi was very much a builder and a craftsman, each of his buildings unique yet based on his knowledge of the materials and the techniques for working with them.
-
-Fat chance this code is going to be a masterpiece, but you have to aspire to something.
-
-## Whatever for?
-
-Well, I've done this 4 times now and some things keep getting reused and some things are improved and I have reached the point where it is easier to clone a base repository with properly tested code and fill in the blanks than actually find the previous system and remove project specific stuff.
-
-## Will it make coffee?
-
-Under specific circumstances, yes!
-
-Gaudi is ostensibly a build system for component-based, multi-platform, statically linked C or C++ projects of the kind you usually get when you are creating embedded systems. In truth it's an all dancing, all singing automation tool that happens to know how to compile code.
-
-It probably won't scale down. It's hodge-podge predecessors have been servicing teams of 7+, with projects running for longer than a year and LOC counts in the high 100Ks. Then again if you follow the default conventions it will work out of the box for any code size.
 
 ## Goals
 
 The main goals for Gaudi are:
 
  * Provide a simple, centralized way for configuring a development environment beginning with the build
- * Codify a set of conventions for projects targeting multiple platforms. 
+ * Codify a set of conventions for projects targeting multiple platforms.
  * Form the basis for a consistent CLI interface between the developers and the development environment
 
 Check the [documentation](doc/README.md) for more details.
+
+## Will it make coffee?
+
+Under specific circumstances, yes!
+
+Gaudi is ostensibly a build system for component-based, multi-platform, statically linked C or C++ projects of the kind you usually get when you are creating embedded systems.
+
+In truth the build system is rake and gaudi is a set of conventions and helper code for a consistent command line interface aimed at controlling every aspect of the development environment, from compile and link to test, package, release and deployment.
+
+The open source core just happens to know how to build C/C++ programs.
+
+## Whatever for?
+
+Well, I've done this several times now and some things keep getting reused and some things are improved and I have reached the point where it is easier to clone a base repository with properly tested code and fill in the blanks than actually find the previous system and remove project specific stuff.
+
+## Gaudi?
+
+Well, if you know who [Gaudi](http://en.wikipedia.org/wiki/Antoni_Gaud%C3%AD) was you should concentrate on the fact that he rarely produced detailed plans of his works, he created models.
+
+Gaudi was very much a builder and a craftsman, each of his buildings unique yet based on his knowledge of the materials and the techniques for working with them.
 
 ## LICENSE:
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -58,7 +58,7 @@ rake task FOO=bar
 
 Gaudi supports a set of environment variables as a way for passing options and exposes these as attributes of the system configuration
 
- * GAUDI_CONFIG - points to the cofniguration file. This needs to be set, Gaudi will exit with an error if it's empty or the file does not exist
+ * GAUDI_CONFIG - points to the configuration file. This needs to be set, Gaudi will exit with an error if it's empty or the file does not exist
  * DEPLOYMENT - passes the deployment name
  * COMPONENT - passes the component name
  * USER - passes the user name

--- a/doc/MODULES.md
+++ b/doc/MODULES.md
@@ -1,0 +1,35 @@
+#Gaudi modules
+
+The modules concept allows us to add code to gaudi installations from multiple sources and have it be required and integrated in the way that gaudi core expects.
+
+A "module" is a copy of the 'custom' directory structure:
+
+* helpers - a directory for library code. All .rb files here are automatically required during the configuration process
+* rules - rake rules. All .rb files here are automatically required during the configuration process and after the module's helpers.
+* tasks - a directory for rake tasks. All files here are automatically required after gaudi is configured. All helpers are guaranteed to be available at this stage.
+
+##Using modules
+
+* Create a directory under tools/build/lib and name it after your module.
+* Place files in the appropriate subfolders.
+* Work
+
+##Managing modules
+
+The gaudi gem offers a way to download/update modules from git repositories.
+
+The git repository needs to mirror the structure of gaudi core (a lib/module_name directory)
+
+```
+gaudi -l foo https://module.source/foo.git my_project
+```
+
+So you can keep your supre-extra-reusable-generic-code in a separate repository and share between projects.
+
+##What about 'custom' and path conventions?
+
+The modules concept exists since v0.12.0.
+
+'custom' is just another module, but it is always included in the list for backward compatibility reasons.
+
+It's also a good way to provide an example and separate the project specific path conventions from core. You can omit 'custom' and place paths.rb in your own module.

--- a/doc/REASONINGS.md
+++ b/doc/REASONINGS.md
@@ -2,9 +2,9 @@
 
 While the parts of Gaudi that are published deal with building C/C++ programs, project specific applications include static code analysis, IDE project generation, documentation generation, test execution, reporting and release management and more or less every task you could automate in a software project.
 
-Experience shows that even if you narrow down the scope (to say embedded C projects for very constrained devices) every project develops differently. The decision to avoid publishing a gem is based on this fact and a usage scenario as it developed over 4 years of using rake to build embedded systems.
+Experience shows that even if you narrow down the scope (to say embedded C projects for very constrained devices) every project develops differently. The decision to avoid publishing a gem is based on this fact and a usage scenario as it developed over several years of using rake to build embedded systems.
 
-Basically the build system is versioned within the project repository and does not need the extra versioning layer a gem provides. The speed of propagating the build system changes in a project under heavy development is much more important - a git pull should suffice. Also bundling as a gem introduces a disconnect between the version that is committed and the version that is installed in the development environment with sometimes unnerving consequences.
+Basically the build system is versioned within the project repository and does not need the extra versioning layer a gem provides. The speed of propagating  build system changes in a project under heavy development is much more important - a git pull should suffice. Also bundling as a gem introduces a disconnect between the version that is committed and the version that is installed in the development environment with sometimes unnerving consequences.
 
 Having said that, you do need a plan for managing the inevitable cornucopia of gems that will be used in implementing tasks.
 

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -1,0 +1,43 @@
+#The Gaudi Coding Style
+
+##System configuration
+
+Gaudi exposes the system configuration in a global variable called $configuration.
+
+We refer to $configuration **only** within tasks. NO gaudi helper module or method with EVER access $configuration directly. The system configuration is always passed to the method as a parameter names system_config.
+
+##Method parameters
+
+Method parameters are defined from specific to generic and the last two are always system_config,platform (when the method is platform independent, then system_sonfig is the last parameter).
+
+```ruby
+def determine_directories name,source_directories,system_config,platform
+#...
+end
+def compile filetask,system_config,platform
+#...
+end
+```
+
+##Helpers & Tasks
+
+The code is organized in modules and each task includes the modules needed
+
+```ruby
+desc "Builds the deployment specified with DEPLOYMENT.\n rake build:deployment DEPLOYMENT=Foo"
+task :deployment do
+  include Gaudi::Tasks::Build
+  deployment=Gaudi::Deployment.new($configuration.deployment,$configuration)
+  t=deployment_task(deployment,$configuration)
+  Rake::Task[t].invoke
+end
+```
+
+##Parametrizing tasks
+
+Rake allows us to create tasks that accept parameters  but in gaudi we chose to use environment variables.
+
+This allows us to easily set defaults in development environment installations.
+
+Gaudi offers a mechanism for integration of environment variables in the system configuration (see [CONFIGURATION](CONFIGURATION.md) for details).
+

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -4,11 +4,11 @@
 
 Gaudi exposes the system configuration in a global variable called $configuration.
 
-We refer to $configuration **only** within tasks. NO gaudi helper module or method with EVER access $configuration directly. The system configuration is always passed to the method as a parameter names system_config.
+We refer to $configuration **only** within tasks. NO gaudi helper module or method with EVER access $configuration directly. The system configuration is always passed to the method as a parameter named system_config.
 
 ##Method parameters
 
-Method parameters are defined from specific to generic and the last two are always system_config,platform (when the method is platform independent, then system_sonfig is the last parameter).
+Method parameters are defined from specific to generic and the last two are always system_config,platform (when the method is platform independent, then system_config is the last parameter).
 
 ```ruby
 def determine_directories name,source_directories,system_config,platform

--- a/gem/History.txt
+++ b/gem/History.txt
@@ -2,6 +2,7 @@
 * Added *deployments* and *common* subdirectories when scaffolding src
 * Added an empty library configuration file and the platform config reference
 * Added the *auto_rules* option in the system configuration
+* Pull Gaudi "libraries" with -l
 
 #0.2.4
 * Fix bug when project root contains spaces

--- a/lib/custom/helpers/paths.rb
+++ b/lib/custom/helpers/paths.rb
@@ -1,3 +1,4 @@
+require_relative '../../gaudi/helpers/operations'
 module Gaudi
   #This is the default directory layout:
   # src/platform

--- a/lib/gaudi.rb
+++ b/lib/gaudi.rb
@@ -7,8 +7,6 @@ include Gaudi::Utilities
 
 #load every file you find in the helpers directory
 mass_require(Rake::FileList["#{File.join(File.dirname(__FILE__),'gaudi/helpers')}/*.rb"].exclude("utilities.rb"))
-mass_require(Rake::FileList["#{File.join(File.dirname(__FILE__),'custom/helpers')}/*.rb"])
-mass_require(Rake::FileList["#{File.join(File.dirname(__FILE__),'custom/rules')}/*.rb"])
 
 module Gaudi::Utilities
   #Reads the configuration and sets the environment up
@@ -29,6 +27,7 @@ module Gaudi::Utilities
           include Gaudi::Rules::Build
           all_rules(system_config)
         end
+        require_modules(system_config)
         $configuration=system_config
       else
         raise GaudiError,"Did not specify a configuration.\n Add GAUDI_CONFIG=path/to/config to the commandline or specify the GAUDI_CONFIG environment variable"

--- a/lib/gaudi.rb
+++ b/lib/gaudi.rb
@@ -27,7 +27,6 @@ module Gaudi::Utilities
           include Gaudi::Rules::Build
           all_rules(system_config)
         end
-        require_modules(system_config)
         $configuration=system_config
       else
         raise GaudiError,"Did not specify a configuration.\n Add GAUDI_CONFIG=path/to/config to the commandline or specify the GAUDI_CONFIG environment variable"

--- a/lib/gaudi/helpers/configuration.rb
+++ b/lib/gaudi/helpers/configuration.rb
@@ -1,4 +1,5 @@
 require_relative '../version'
+require_relative 'errors'
 require 'pathname'
 require 'yaml'
 require 'delegate'
@@ -306,7 +307,7 @@ module Gaudi
         include ConfigurationOperations
         #:stopdoc:
         def self.list_keys
-          ['platforms','sources']
+          ['platforms','sources','gaudi_modules']
         end
         def self.path_keys
           ['base','out','sources']
@@ -328,6 +329,13 @@ module Gaudi
         #List of directories containing sources
         def sources
           @config["sources"].map{|d| File.expand_path(d)}
+        end
+        #A list of module names (directories) to automatically require next to core when loading Gaudi
+        #
+        #For backward compatibility reasons "custom" is always added to the list of modules
+        def gaudi_modules
+          @config["gaudi_modules"]<<"custom" unless @config["gaudi_modules"].include?("custom")
+          return @config["gaudi_modules"]
         end
         #returns the platform configuration hash
         def platform_config platform

--- a/lib/gaudi/helpers/configuration.rb
+++ b/lib/gaudi/helpers/configuration.rb
@@ -50,7 +50,7 @@ module Gaudi
         begin
           puts "Switching platform configuration for #{platform} to #{configuration_file}"
           current_config=system_config.platform_config(platform)
-          new_cfg_data=system_config.read_configuration(configuration_file)
+          new_cfg_data=system_config.read_configuration(File.expand_path(configuration_file))
           system_config.set_platform_config(PlatformConfiguration.new(platform,new_cfg_data),platform)
           yield
         rescue
@@ -303,11 +303,11 @@ module Gaudi
       #before we start reading the configuration to ensure that extension modules work correctly
       def load_gaudi_modules main_config_file
           lines=File.readlines(main_config_file)
-          lines.select! do |ln|
+          relevant_lines=lines.select do |ln|
             /base=/=~ln || /gaudi_modules=/=~ln
           end
-          cfg=parse_content(lines,File.dirname(main_config_file),*keys)
-          require_modules(cfg["gaudi_modules"],cfg["base"])
+          cfg=parse_content(relevant_lines,File.dirname(main_config_file),*keys)
+          require_modules(cfg.fetch("gaudi_modules",[]),cfg["base"])
       end
       #Iterates over system_config.gaudi_modules and requires all helper files
       def require_modules module_list,base_directory

--- a/lib/gaudi/helpers/configuration.rb
+++ b/lib/gaudi/helpers/configuration.rb
@@ -50,7 +50,7 @@ module Gaudi
         begin
           puts "Switching platform configuration for #{platform} to #{configuration_file}"
           current_config=system_config.platform_config(platform)
-          new_cfg_data=system_config.read_configuration(configuration_file,*system_config.keys)
+          new_cfg_data=system_config.read_configuration(configuration_file)
           system_config.set_platform_config(PlatformConfiguration.new(platform,new_cfg_data),platform)
           yield
         rescue
@@ -123,7 +123,7 @@ module Gaudi
       attr_reader :config
       def initialize filename
         @configuration_files=[File.expand_path(filename)]
-        @config=read_configuration(File.expand_path(filename),*keys)
+        @config=read_configuration(File.expand_path(filename))
       end
       #Returns an Array containing two arrays.
       #
@@ -144,7 +144,7 @@ module Gaudi
       #Merges the parameters from cfg_file into this instance
       def merge cfg_file
         begin
-          cfg=read_configuration(cfg_file,*keys)
+          cfg=read_configuration(cfg_file)
           list_keys,path_keys=*keys
           cfg.keys.each do |k|
             if @config.keys.include?(k) && list_keys.include?(k)
@@ -160,36 +160,43 @@ module Gaudi
       end
       #Reads a configuration file and returns a hash with the
       #configuration as key-value pairs
-      def read_configuration filename,list_keys,path_keys
+      def read_configuration filename
         if File.exists?(filename)
           lines=File.readlines(filename)
-          cfg={}
           cfg_dir=File.dirname(filename)
-
-          lines.each do |l|
-            l.gsub!("\t","")
-            l.chomp!
-            #ignore if it starts with a hash
-            unless l=~/^#/ || l.empty?
-              if /^setenv\s+(?<envvar>.+?)\s*=\s*(?<val>.*)/ =~ l
-                environment_variable(envvar,val)
-              #if it starts with an import get a new config file
-              elsif /^import\s+(?<path>.*)/ =~ l
-                cfg.merge!(import_config(path,cfg_dir))
-              elsif /^(?<key>.*?)\s*=\s*(?<v>.*)/ =~ l
-                cfg[key]=handle_key(key,v,cfg_dir,list_keys,path_keys,cfg)
-              else
-                raise GaudiConfigurationError,"Configuration syntax error in #{filename}:\n'#{l}'"
-              end
-            end#unless
-          end#lines.each
+          begin
+            cfg=parse_content(lines,cfg_dir,*keys)
+          rescue GaudiConfigurationError
+            raise GaudiConfigurationError,"In #{filename} - #{$!.message}"
+          end
         else
           raise GaudiConfigurationError,"Cannot load configuration.'#{filename}' not found"
         end
         return cfg
       end
       private
-      #:nodoc:
+      #:stopdoc:
+      def parse_content lines,cfg_dir,list_keys,path_keys
+        cfg={}
+        lines.each do |l|
+          l.gsub!("\t","")
+          l.chomp!
+          #ignore if it starts with a hash
+          unless l=~/^#/ || l.empty?
+            if /^setenv\s+(?<envvar>.+?)\s*=\s*(?<val>.*)/ =~ l
+              environment_variable(envvar,val)
+            #if it starts with an import get a new config file
+            elsif /^import\s+(?<path>.*)/ =~ l
+              cfg.merge!(import_config(path,cfg_dir))
+            elsif /^(?<key>.*?)\s*=\s*(?<v>.*)/ =~ l
+              cfg[key]=handle_key(key,v,cfg_dir,list_keys,path_keys,cfg)
+            else
+              raise GaudiConfigurationError,"Syntax error: '#{l}'"
+            end
+          end#unless
+        end#lines.each
+        return cfg
+      end
       def required_path fname
         if fname && !fname.empty?
           if File.exists?(fname)
@@ -220,14 +227,12 @@ module Gaudi
         end
         return final_value
       end
-      #:nodoc:
       def import_config path,cfg_dir
         path=absolute_path(path.strip,cfg_dir)
         raise GaudiConfigurationError,"Cannot find #{path} to import" unless File.exists?(path)
         @configuration_files<<path
-        read_configuration(path,*keys)
+        read_configuration(path)
       end
-      #:nodoc:
       def absolute_path path,cfg_dir
         if Pathname.new(path.gsub("\"","")).absolute?
           path
@@ -235,11 +240,10 @@ module Gaudi
           File.expand_path(File.join(cfg_dir,path.gsub("\"","")))
         end
       end
-      #:nodoc:
       def environment_variable(envvar,value)
         ENV[envvar]=value
       end
-      #:nodoc:
+      
       def load_key_modules module_const
         list_keys=[]
         path_keys=[]
@@ -253,6 +257,7 @@ module Gaudi
         end
         return list_keys,path_keys
       end
+      #:startdoc:
     end
     #The central configuration for the system
     #
@@ -267,6 +272,7 @@ module Gaudi
 
       attr_accessor :config_base,:workspace,:timestamp
       def initialize filename
+        load_gaudi_modules(File.expand_path(filename))
         super(filename)
         @config_base=File.dirname(configuration_files.first)
         raise GaudiConfigurationError, "Setting 'base' must be defined" unless base
@@ -281,18 +287,37 @@ module Gaudi
       end
 
       private
-      #:nodoc:
+      #:stopdoc:
       def load_platform_configurations
         @config['platform_data']={}
         @config['platforms']||=[]
         platforms.each do |platform_name|
           path=@config[platform_name]
           path=File.expand_path(File.join(@config_base,path)) if !Pathname.new(path).absolute?
-          pdata=read_configuration(path,*keys)
+          pdata=read_configuration(path)
           @configuration_files<<path
           @config['platform_data'][platform_name]=PlatformConfiguration.new(platform_name,pdata)
         end
       end
+      #makes sure we require the helper from any modules defined in the configuration
+      #before we start reading the configuration to ensure that extension modules work correctly
+      def load_gaudi_modules main_config_file
+          lines=File.readlines(main_config_file)
+          lines.select! do |ln|
+            /base=/=~ln || /gaudi_modules=/=~ln
+          end
+          cfg=parse_content(lines,File.dirname(main_config_file),*keys)
+          require_modules(cfg["gaudi_modules"],cfg["base"])
+      end
+      #Iterates over system_config.gaudi_modules and requires all helper files
+      def require_modules module_list,base_directory
+        module_list.each do |gm|
+          mass_require(Rake::FileList["#{base_directory}/tools/build/lib/#{gm}/helpers/*.rb"])
+          mass_require(Rake::FileList["#{base_directory}/tools/build/lib/#{gm}/rules/*.rb"])
+        end
+      end
+
+      #:startdoc:
     end
     #Adding modules in this module allows SystemConfiguration to extend it's functionality
     #
@@ -334,6 +359,7 @@ module Gaudi
         #
         #For backward compatibility reasons "custom" is always added to the list of modules
         def gaudi_modules
+          @config["gaudi_modules"]||=[]
           @config["gaudi_modules"]<<"custom" unless @config["gaudi_modules"].include?("custom")
           return @config["gaudi_modules"]
         end

--- a/lib/gaudi/helpers/generators.rb
+++ b/lib/gaudi/helpers/generators.rb
@@ -133,8 +133,9 @@ module Gaudi
       def executable_rule system_config,platform
         platform_config=system_config.platform_config(platform)
         _,_,exe=platform_config.extensions
-
-        rule(/#{platform}\/.*#{exe}/) do |t|
+        #we configure them with dots which messes the regexp up
+        ext=exe.gsub(".","")
+        rule(/#{platform}\/.*\.#{ext}$/) do |t|
           include Gaudi::ArtifactAdapters::Build
           build(t,system_config,platform)
         end
@@ -143,8 +144,9 @@ module Gaudi
       def object_rule system_config,platform
         platform_config=system_config.platform_config(platform)
         obj,_,_=platform_config.extensions
-
-        rule(/#{platform}\/.*#{obj}/) do |t|
+        #we configure them with dots which messes the regexp up
+        ext=obj.gsub(".","")
+        rule(/#{platform}\/.*\.#{ext}$/) do |t|
           include Gaudi::ArtifactAdapters::Build
           compile(t,system_config,platform)
         end

--- a/lib/gaudi/helpers/utilities.rb
+++ b/lib/gaudi/helpers/utilities.rb
@@ -14,13 +14,6 @@ module Gaudi
         end
       end
     end
-    #Iterates over system_config.gaudi_modules and requires all helper files
-    def require_modules system_config
-      system_config.gaudi_modules.each do |gm|
-        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/helpers/*.rb"])
-        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/rules/*.rb"])
-      end
-    end
     #Iterates over system_config.gaudi_modules and requires all tasks
     def require_tasks system_config
       system_config.gaudi_modules.each do |gm|

--- a/lib/gaudi/helpers/utilities.rb
+++ b/lib/gaudi/helpers/utilities.rb
@@ -14,6 +14,13 @@ module Gaudi
         end
       end
     end
+    #Iterates over system_config.gaudi_modules and requires all files
+    def require_modules system_config
+      system_config.gaudi_modules.each do |gm|
+        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/helpers')}/*.rb"])
+        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/rules')}/*.rb"])
+      end
+    end
     #Writes a file making sure the directory is created
     def write_file filename,content
       mkdir_p(File.dirname(filename),:verbose=>false)

--- a/lib/gaudi/helpers/utilities.rb
+++ b/lib/gaudi/helpers/utilities.rb
@@ -14,11 +14,17 @@ module Gaudi
         end
       end
     end
-    #Iterates over system_config.gaudi_modules and requires all files
+    #Iterates over system_config.gaudi_modules and requires all helper files
     def require_modules system_config
       system_config.gaudi_modules.each do |gm|
-        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/helpers')}/*.rb"])
-        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/rules')}/*.rb"])
+        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/helpers/*.rb"])
+        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/rules/*.rb"])
+      end
+    end
+    #Iterates over system_config.gaudi_modules and requires all tasks
+    def require_tasks system_config
+      system_config.gaudi_modules.each do |gm|
+        mass_require(Rake::FileList["#{system_config.base}/tools/build/lib/#{gm}/tasks/*.rb"])
       end
     end
     #Writes a file making sure the directory is created

--- a/lib/gaudi/tasks.rb
+++ b/lib/gaudi/tasks.rb
@@ -2,4 +2,4 @@ require_relative '../gaudi'
 
 #load every file you find in the tasks directory
 mass_require(FileList["#{File.join(File.dirname(__FILE__),'tasks')}/*.rb"])
-mass_require(FileList["#{File.join(File.dirname(__FILE__),'../custom/tasks')}/*.rb"])
+require_tasks($configuration)

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -1,5 +1,5 @@
 module TestHelpers
-  def mock_configuration filename,lines
+  def mock_system_configuration filename,lines
     fname=File.join(File.dirname(__FILE__),filename)
     File.stubs(:exists?).with(fname).returns(true)
     File.stubs(:readlines).with(fname).returns(lines)

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -1,10 +1,9 @@
 require_relative '../lib/custom/helpers/paths'
-require_relative '../lib/gaudi/helpers/generators'
-require_relative 'helpers.rb'
+require_relative '../lib/gaudi'
+require_relative 'helpers'
 require "minitest/autorun"
 require "mocha/setup"
 require "rake/file_list"
-require "gaudi"
 require "rake"
 include Rake::DSL
 

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -1,11 +1,14 @@
-$:.unshift(File.join(File.dirname(__FILE__),'..','lib'))
+require_relative '../lib/custom/helpers/paths'
+require_relative '../lib/gaudi/helpers/generators'
 require_relative 'helpers.rb'
 require "minitest/autorun"
 require "mocha/setup"
 require "rake/file_list"
 require "gaudi"
+require "rake"
+include Rake::DSL
 
-class TestStandardPaths < MiniTest::Unit::TestCase
+class TestStandardPaths < Minitest::Test
   include Gaudi::StandardPaths
   def test_filenames
     component=mock()
@@ -33,7 +36,7 @@ class TestStandardPaths < MiniTest::Unit::TestCase
   end
 end
 
-class TestComponent< MiniTest::Unit::TestCase
+class TestComponent< Minitest::Test
   attr_reader :src_dir,:system_config
   include TestHelpers
   def setup
@@ -68,7 +71,7 @@ class TestComponent< MiniTest::Unit::TestCase
   end
 end
 
-class TestDeployment< MiniTest::Unit::TestCase
+class TestDeployment< Minitest::Test
   attr_reader :src_dir,:system_config
   include TestHelpers
   def setup

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,9 +1,8 @@
 require_relative '../lib/custom/helpers/paths'
-require_relative '../lib/gaudi/helpers/configuration'
+require_relative '../lib/gaudi'
 require_relative 'helpers'
 require "minitest/autorun"
 require "mocha/setup"
-require "gaudi"
 require "rake"
 
 class TestLoader < Minitest::Test

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -8,21 +8,21 @@ require "rake"
 class TestLoader < Minitest::Test
   include TestHelpers
   def test_empty_configuration
-    config=mock_configuration('system.cfg',[])
+    config=mock_system_configuration('system.cfg',[])
     cfg=Gaudi::Configuration::Loader.new(config)
     assert_equal([config], cfg.configuration_files)
   end
   def test_syntax_error
-    config=mock_configuration('system.cfg',['foo'])
+    config=mock_system_configuration('system.cfg',['foo'])
     assert_raises(GaudiConfigurationError) { Gaudi::Configuration::Loader.new(config) }
   end
   def test_comments
-    config=mock_configuration('system.cfg',['','#comment'])
+    config=mock_system_configuration('system.cfg',['','#comment'])
     cfg=Gaudi::Configuration::Loader.new(config)
     assert(cfg.config.empty?, "Configuration should be empty")
   end
   def test_import
-    config=mock_configuration('system.cfg',['import import.cfg'])
+    config=mock_system_configuration('system.cfg',['import import.cfg'])
     File.expects(:exists?).with(File.join(File.dirname(config),"import.cfg")).returns(true).times(2)
     File.expects(:readlines).with(File.join(File.dirname(config),"import.cfg")).returns(['foo=bar'])
     cfg=Gaudi::Configuration::Loader.new(config)
@@ -30,19 +30,19 @@ class TestLoader < Minitest::Test
     assert_equal('bar', cfg.config['foo'])
   end
   def test_property_reference
-    config=mock_configuration('system.cfg',['foo=bar','bar=%{foo}'])
+    config=mock_system_configuration('system.cfg',['foo=bar','bar=%{foo}'])
     cfg=Gaudi::Configuration::Loader.new(config)
     assert(!cfg.config.empty?, "Configuration should not be empty")
     assert_equal('bar', cfg.config['foo'])
   end
   def test_property_self_reference
-    config=mock_configuration('system.cfg',['foo=bar','foo=%{foo}*%{foo}'])
+    config=mock_system_configuration('system.cfg',['foo=bar','foo=%{foo}*%{foo}'])
     cfg=Gaudi::Configuration::Loader.new(config)
     assert(!cfg.config.empty?, "Configuration should not be empty")
     assert_equal('bar*bar', cfg.config['foo'])
   end
   def test_environment
-    config=mock_configuration('system.cfg',['setenv GAUDI = brilliant builder'])
+    config=mock_system_configuration('system.cfg',['setenv GAUDI = brilliant builder'])
     Gaudi::Configuration::Loader.new(config)
     assert_equal('brilliant builder',ENV['GAUDI'])
   end
@@ -51,12 +51,12 @@ end
 class TestSystemConfiguration < Minitest::Test
   include TestHelpers
   def test_empty_configuration
-    config=mock_configuration('system.cfg',[])
+    config=mock_system_configuration('system.cfg',[])
     assert_raises(GaudiConfigurationError) {  Gaudi::Configuration::SystemConfiguration.new(config)}
   end
 
   def test_basic_configuration
-    config=mock_configuration('system.cfg',['base=.','out=out/'])
+    config=mock_system_configuration('system.cfg',['base=.','out=out/'])
     cfg=Gaudi::Configuration::SystemConfiguration.new(config)
     assert_equal(File.expand_path(File.dirname(__FILE__)), cfg.base_dir)
     assert_equal(File.expand_path(File.join(File.dirname(__FILE__),'out')), cfg.out_dir)
@@ -65,13 +65,13 @@ class TestSystemConfiguration < Minitest::Test
 
   def test_load
     assert_raises(GaudiConfigurationError) { Gaudi::Configuration::SystemConfiguration.load([])}
-    config=mock_configuration('system.cfg',['base=.','out=out/'])
+    config=mock_system_configuration('system.cfg',['base=.','out=out/'])
     cfg=Gaudi::Configuration::SystemConfiguration.load([config])
     assert_equal(File.dirname(__FILE__),cfg.base)
   end
 
   def test_platforms
-    config=mock_configuration('system.cfg',system_config_test_data)
+    config=mock_system_configuration('system.cfg',system_config_test_data)
     platform_cfg=File.join(File.dirname(__FILE__),'foo.cfg')
     File.expects(:exists?).with(platform_cfg).returns(true)
     File.expects(:readlines).with(platform_cfg).returns(platform_config_test_data+['bar=foo'])
@@ -83,14 +83,14 @@ class TestSystemConfiguration < Minitest::Test
   end
   
   def test_list_of_paths
-    config=mock_configuration('system.cfg',['base=.','out=out/','sources= src,tmp,../out'])
+    config=mock_system_configuration('system.cfg',['base=.','out=out/','sources= src,tmp,../out'])
     cfg=Gaudi::Configuration::SystemConfiguration.new(config)
     paths=[File.join(File.dirname(config),'src'),File.join(File.dirname(config),'tmp'),File.expand_path(File.join(File.dirname(config),'..','out'))]
     assert_equal(paths,cfg.sources)
   end
 
   def test_external_libraries
-    config=mock_configuration('system.cfg',system_config_test_data)
+    config=mock_system_configuration('system.cfg',system_config_test_data)
     platform_cfg=File.join(File.dirname(__FILE__),'foo.cfg')
     File.expects(:exists?).with(platform_cfg).returns(true)
     File.expects(:readlines).with(platform_cfg).returns(platform_config_test_data+['libs=foo','lib_cfg=libs.yml'])
@@ -104,7 +104,7 @@ class TestSystemConfiguration < Minitest::Test
   end
 
   def test_external_libraries_missing_lib_cfg
-    config=mock_configuration('system.cfg',system_config_test_data)
+    config=mock_system_configuration('system.cfg',system_config_test_data)
     platform_cfg=File.join(File.dirname(__FILE__),'foo.cfg')
     File.expects(:exists?).with(platform_cfg).returns(true)
     File.expects(:readlines).with(platform_cfg).returns(['source_extensions=.c,.cpp','header_extensions=.h',
@@ -117,7 +117,7 @@ class TestSystemConfiguration < Minitest::Test
   end
 
   def test_external_libraries_missing_token
-    config=mock_configuration('system.cfg',system_config_test_data)
+    config=mock_system_configuration('system.cfg',system_config_test_data)
     platform_cfg=File.join(File.dirname(__FILE__),'foo.cfg')
     File.expects(:exists?).with(platform_cfg).returns(true)
     File.expects(:readlines).with(platform_cfg).returns(platform_config_test_data+[
@@ -131,7 +131,7 @@ class TestSystemConfiguration < Minitest::Test
   end
 
   def test_external_includes
-    config=mock_configuration('system.cfg',system_config_test_data)
+    config=mock_system_configuration('system.cfg',system_config_test_data)
     platform_cfg=File.join(File.dirname(__FILE__),'foo.cfg')
     File.expects(:exists?).with(platform_cfg).returns(true)
     File.expects(:readlines).with(platform_cfg).returns(platform_config_test_data+['incs=./foo,./bar'])
@@ -140,7 +140,7 @@ class TestSystemConfiguration < Minitest::Test
     assert_equal(["#{File.dirname(__FILE__)}/foo", "#{File.dirname(__FILE__)}/bar"],cfg.external_includes('foo'))
   end
   def test_external_includes_empty
-    config=mock_configuration('system.cfg',system_config_test_data)
+    config=mock_system_configuration('system.cfg',system_config_test_data)
     platform_cfg=File.join(File.dirname(__FILE__),'foo.cfg')
     File.expects(:exists?).with(platform_cfg).returns(true)
     File.expects(:readlines).with(platform_cfg).returns(platform_config_test_data)
@@ -149,7 +149,7 @@ class TestSystemConfiguration < Minitest::Test
   end
 
   def test_extensions
-    config=mock_configuration('system.cfg',system_config_test_data)
+    config=mock_system_configuration('system.cfg',system_config_test_data)
     platform_cfg=File.join(File.dirname(__FILE__),'foo.cfg')
     File.expects(:exists?).with(platform_cfg).returns(true)
     File.expects(:readlines).with(platform_cfg).returns(platform_config_test_data)
@@ -161,14 +161,14 @@ end
 class TestBuildConfiguration < Minitest::Test
   include TestHelpers
   def test_empty_configuration
-    config=mock_configuration('build.cfg',[])
+    config=mock_system_configuration('build.cfg',[])
     assert_raises(GaudiConfigurationError) {  p Gaudi::Configuration::BuildConfiguration.load([config]) }
   end
 
   def test_basic_configuration
     system_cfg=mock('system')
     system_cfg.stubs(:config_base).returns(File.dirname(__FILE__))
-    config=mock_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','libs= foo,bar','compiler_options= FOO BAR'])
+    config=mock_system_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','libs= foo,bar','compiler_options= FOO BAR'])
     cfg=Gaudi::Configuration::BuildConfiguration.load([config])
     assert_equal('TST', cfg.prefix)
     assert_equal(['COD','MOD'],cfg.deps)
@@ -182,13 +182,13 @@ class TestBuildConfiguration < Minitest::Test
   end
 
   def test_property_reference
-    config=mock_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','compiler_options= -DMODULE=%{prefix}'])
+    config=mock_system_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','compiler_options= -DMODULE=%{prefix}'])
     cfg=Gaudi::Configuration::BuildConfiguration.load([config])
     assert_equal('-DMODULE=TST',cfg.option('compiler_options'))
   end
   
   def test_load
-    config=mock_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','libs= foo.lib,bar.lib'])
+    config=mock_system_configuration('build.cfg',['prefix=TST','deps=COD,MOD','incs= ./inc','libs= foo.lib,bar.lib'])
     assert_raises(GaudiConfigurationError) { Gaudi::Configuration::BuildConfiguration.load([])}
     cfg=Gaudi::Configuration::BuildConfiguration.load([config])
     assert_equal('TST',cfg.prefix)

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,10 +1,12 @@
-$:.unshift(File.join(File.dirname(__FILE__),'..','lib'))
+require_relative '../lib/custom/helpers/paths'
+require_relative '../lib/gaudi/helpers/configuration'
 require_relative 'helpers'
 require "minitest/autorun"
 require "mocha/setup"
 require "gaudi"
+require "rake"
 
-class TestLoader < MiniTest::Unit::TestCase
+class TestLoader < Minitest::Test
   include TestHelpers
   def test_empty_configuration
     config=mock_configuration('system.cfg',[])
@@ -47,7 +49,7 @@ class TestLoader < MiniTest::Unit::TestCase
   end
 end
 
-class TestSystemConfiguration < MiniTest::Unit::TestCase
+class TestSystemConfiguration < Minitest::Test
   include TestHelpers
   def test_empty_configuration
     config=mock_configuration('system.cfg',[])
@@ -157,7 +159,7 @@ class TestSystemConfiguration < MiniTest::Unit::TestCase
   end
 end
 
-class TestBuildConfiguration < MiniTest::Unit::TestCase
+class TestBuildConfiguration < Minitest::Test
   include TestHelpers
   def test_empty_configuration
     config=mock_configuration('build.cfg',[])
@@ -194,7 +196,7 @@ class TestBuildConfiguration < MiniTest::Unit::TestCase
   end
 end
 
-class TestPlatformConfiguration < MiniTest::Unit::TestCase
+class TestPlatformConfiguration < Minitest::Test
   include TestHelpers
 
   def setup

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -162,7 +162,7 @@ class TestBuildConfiguration < Minitest::Test
   include TestHelpers
   def test_empty_configuration
     config=mock_system_configuration('build.cfg',[])
-    assert_raises(GaudiConfigurationError) {  p Gaudi::Configuration::BuildConfiguration.load([config]) }
+    assert_raises(GaudiConfigurationError) {  Gaudi::Configuration::BuildConfiguration.load([config]) }
   end
 
   def test_basic_configuration

--- a/test/test_generators.rb
+++ b/test/test_generators.rb
@@ -1,14 +1,19 @@
-$:.unshift(File.join(File.dirname(__FILE__),'..','lib'))
 require_relative 'helpers'
+require_relative '../lib/custom/helpers/paths'
+require_relative '../lib/gaudi/helpers/utilities'
+require_relative '../lib/gaudi/helpers/generators'
+require_relative '../lib/gaudi/helpers/components'
+
 require "minitest/autorun"
 require "mocha/setup"
 require "gaudi"
 require 'rake'
 
-class TestTaskGenerators < MiniTest::Unit::TestCase
+class TestTaskGenerators < Minitest::Test
   include TestHelpers
   include Rake::DSL
   include Gaudi::Tasks::Build
+  include Gaudi::Utilities
   def setup
     directory_fixture
   end

--- a/test/test_generators.rb
+++ b/test/test_generators.rb
@@ -1,12 +1,8 @@
 require_relative 'helpers'
 require_relative '../lib/custom/helpers/paths'
-require_relative '../lib/gaudi/helpers/utilities'
-require_relative '../lib/gaudi/helpers/generators'
-require_relative '../lib/gaudi/helpers/components'
-
+require_relative '../lib/gaudi'
 require "minitest/autorun"
 require "mocha/setup"
-require "gaudi"
 require 'rake'
 
 class TestTaskGenerators < Minitest::Test

--- a/test/test_generators.rb
+++ b/test/test_generators.rb
@@ -50,7 +50,7 @@ class TestTaskGenerators < Minitest::Test
     assert(deployment_task(deployment,system_config))
   end
 end
-class TestRuleGenerators < MiniTest::Unit::TestCase
+class TestRuleGenerators < MiniTest::Test
   include TestHelpers
   include Rake::DSL
   include Gaudi::Tasks::Build

--- a/test/test_platform_operations.rb
+++ b/test/test_platform_operations.rb
@@ -1,10 +1,9 @@
-$:.unshift(File.join(File.dirname(__FILE__),'..','lib'))
 require_relative 'helpers'
 require "minitest/autorun"
 require "mocha/setup"
 require "gaudi"
 
-class TestPlatformOperations < MiniTest::Unit::TestCase
+class TestPlatformOperations < Minitest::Test
   include Gaudi::PlatformOperations
   def test_source_detection
     assert(is_source?('foo.c'), "It's a source file dummy")

--- a/test/test_platform_operations.rb
+++ b/test/test_platform_operations.rb
@@ -1,7 +1,7 @@
 require_relative 'helpers'
+require_relative '../lib/gaudi'
 require "minitest/autorun"
 require "mocha/setup"
-require "gaudi"
 
 class TestPlatformOperations < Minitest::Test
   include Gaudi::PlatformOperations

--- a/test/test_utilities.rb
+++ b/test/test_utilities.rb
@@ -1,7 +1,7 @@
 require_relative 'helpers'
+require_relative '../lib/gaudi'
 require "minitest/autorun"
 require "mocha/setup"
-require "gaudi"
 
 class TestUtilities < Minitest::Test
   include TestHelpers

--- a/test/test_utilities.rb
+++ b/test/test_utilities.rb
@@ -14,13 +14,19 @@ class TestUtilities < Minitest::Test
   end
   def test_switch_platform_configuration
     File.stubs(:exists?).returns(true)
-    File.expects(:readlines).returns(platform_config_test_data+['foo=bar'])
-    File.expects(:readlines).returns(platform_config_test_data)
-    File.expects(:readlines).returns(system_config_test_data)
-    config=Gaudi::Configuration::SystemConfiguration.new('bar.cfg')
-    Gaudi::Configuration.switch_platform_configuration './foo.cfg',config,'foo' do
-      assert_equal('bar', config.platform_config('foo')['foo'])
+    
+    mock_config=File.expand_path('system.cfg')
+    File.stubs(:readlines).with(mock_config).returns(system_config_test_data)
+
+    mock_foo=File.expand_path('foo.cfg')
+    mock_bar=File.expand_path('bar.cfg')
+    File.expects(:readlines).with(mock_bar).returns(platform_config_test_data+['foo=bar'])
+    File.expects(:readlines).with(mock_foo).returns(platform_config_test_data)
+    
+    system_config=Gaudi::Configuration::SystemConfiguration.new(mock_config)
+    Gaudi::Configuration.switch_platform_configuration './bar.cfg',system_config,'foo' do
+      assert_equal('bar', system_config.platform_config('foo')['foo'])
     end
-    assert_nil(config.platform_config('foo')['foo'])
+    assert_nil(system_config.platform_config('foo')['foo'])
   end
 end

--- a/test/test_utilities.rb
+++ b/test/test_utilities.rb
@@ -1,10 +1,9 @@
-$:.unshift(File.join(File.dirname(__FILE__),'..','lib'))
 require_relative 'helpers'
 require "minitest/autorun"
 require "mocha/setup"
 require "gaudi"
 
-class TestUtilities < MiniTest::Unit::TestCase
+class TestUtilities < Minitest::Test
   include TestHelpers
   def test_switch_configuration
     Gaudi::Configuration::SystemConfiguration.stubs(:load).returns([])


### PR DESCRIPTION
We need a way to add helpers, rules and tasks from multiple sources.
Basically because we re-use much of the proprietary code created outside of core that it makes no sense to copy-paste it over and over again (much like what drove the creation of gaudi core in the first place)

The basic idea adds a configuration directive that tells gaudi to require the contents of a list of library directories that follow the structure of 'custom'.

Support in the gaudi gem should make pulling "libraries" an easy task. No versioning concept yet, no real requirement for it.