### PR TITLE
Basic shell handling in command lines

### DIFF
--- a/lib/gaudi/helpers/operations.rb
+++ b/lib/gaudi/helpers/operations.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+require_relative 'utilities'
 module Gaudi
   #Functions that return platform dependent information
   #
@@ -42,6 +44,7 @@ module Gaudi
   end
   #Methods for creating and managing tool command lines
   module ToolOperations
+    include Gaudi::Utilities
     #Returns the compiler command line options merging the options from all
     #cofniguration files
     def compiler_options src,component,system_config
@@ -90,13 +93,26 @@ module Gaudi
     end
     #returns the commandline for cmd as an Array
     def command_line cmd,cmdfile,prefix
-      cmdline= [cmd]
+      if windows?
+        cmdline= ["\"#{cmd}\""]
+      else
+        cmdline=[cmd]
+      end
       if prefix && !prefix.empty?
-        cmdline<< "#{prefix}#{cmdfile}"
+        cmdline<< "#{prefix}"
+        if windows?
+          cmdline<<"\"#{cmdfile}\""
+        else
+          cmdline<<cmdfile
+        end
       else
         cmdline+= File.readlines(cmdfile).map{|l| l.strip}
       end
-      cmdline
+      if windows?
+        return cmdline
+      else
+        Shellwords.escape(cmdline)
+      end
     end
     #adds a prefix to a list of filenames/objects
     def prefixed_objects objects,prefix_flag

--- a/lib/gaudi/helpers/utilities.rb
+++ b/lib/gaudi/helpers/utilities.rb
@@ -25,5 +25,13 @@ module Gaudi
       mkdir_p(File.dirname(filename),:verbose=>false)
       File.open(filename, 'wb') {|f| f.write(content) }
     end
+    #Returns true if we are on a windows platform
+    def windows?
+      case RbConfig::CONFIG['host_os']
+       when /mingw|mswin/ then return true
+      else 
+        return false
+      end
+    end
   end
 end


### PR DESCRIPTION
dive off the deep end trying to handle spaces and weird things in command lines.

This most certainly does not cover all edge cases but should at least shelter us from the commonest failure: spaces in windows path  names.
