### PR TITLE
Update gem versions and switch to minitar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'http://rubygems.org'
 
-gem 'highline','~>1.6.19', :require  => false
-gem 'rake','~>10.0.1', :require  => false
+gem 'highline','~>1.7.8', :require  => false
+gem 'rake','~>12.0.0', :require  => false
 gem 'graph','~>2.7.0', :require  => false
-gem 'archive-tar-minitar','~>0.5.2', :require  => false
+gem 'minitar','~>0.6.1', :require  => false
 
 group :development do
   gem 'coveralls', :require => false
-  gem 'hoe','~>3.12.0', :require  => false
-  gem 'mocha','~>0.14.0', :require  => false
-  gem 'minitest','~>5.8.3',:require => false
+  gem 'hoe','~>3.16.0', :require  => false
+  gem 'mocha','~>1.2.1', :require  => false
+  gem 'minitest','~>5.10.1',:require => false
 end

--- a/gem/Manifest.txt
+++ b/gem/Manifest.txt
@@ -2,8 +2,8 @@ History.txt
 Manifest.txt
 README.txt
 bin/gaudi
+lib/gaudi.rb
+lib/gaudi/scaffolding.rb
 lib/gaudi/templates/main.cfg.template
 lib/gaudi/templates/platform.cfg.template
-lib/gaudi/scaffolding.rb
 lib/gaudi/version.rb
-lib/gaudi.rb

--- a/gem/Rakefile
+++ b/gem/Rakefile
@@ -18,7 +18,7 @@ Hoe.spec "gaudi" do |prj|
   prj.description=prj.paragraphs_of('README.txt',1..5).join("\n\n")
   prj.local_rdoc_dir='doc/rdoc'
   prj.readme_file="README.txt"
-  prj.extra_deps<<["archive-tar-minitar","~>0.5.2"]
+  prj.extra_deps<<["minitar","~>0.6.1"]
   prj.spec_extras={:executables=>["gaudi"],:default_executable=>"gaudi"}
 end
 

--- a/gem/lib/gaudi/scaffolding.rb
+++ b/gem/lib/gaudi/scaffolding.rb
@@ -3,7 +3,7 @@ require 'optparse'
 require 'fileutils'
 require 'tmpdir'
 require 'rubygems'
-require 'archive/tar/minitar'
+require 'minitar'
 
 module Gaudi
   class GemError <RuntimeError
@@ -216,7 +216,7 @@ require_relative 'tools/build/lib/gaudi/tasks'
     def unpack pkg,home
       puts "Unpacking in #{home}"
       Dir.chdir(home) do |d|
-        Archive::Tar::Minitar.unpack(pkg, home)
+        Minitar.unpack(pkg, home)
       end
       FileUtils.rm_rf(pkg)
       FileUtils.rm_rf(File.join(home,'pax_global_header'))

--- a/gem/lib/gaudi/version.rb
+++ b/gem/lib/gaudi/version.rb
@@ -5,9 +5,9 @@ module Gaudi
       #Major version
       MAJOR=0
       #Minor version
-      MINOR=3
+      MINOR=4
       #Tiny version
-      TINY=1
+      TINY=0
       #All-in-one
       STRING=[MAJOR,MINOR,TINY].join('.')
     end


### PR DESCRIPTION
Removes the [vulnerable](https://github.com/atoulme/minitar/issues/5) minitar version