### PR TITLE
Graph tasks

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+#1.1.0
+* Added task to create a graph of all available tasks as documentation
+* Fixed an infinite call stack when generating the docs and overriding the invoke method
+
 # 1.0.0
 * Major restructure.
 * Split the C/C++ build functionality off to a separate module. Gaudi core is now just the configuration loader and the build system placement conventions

--- a/lib/gaudi/helpers/doc.rb
+++ b/lib/gaudi/helpers/doc.rb
@@ -1,0 +1,35 @@
+require 'graph'
+module Gaudi
+  module Documentation
+    def task_graph system_config
+      digraph do
+        rotate
+        node_attribs << filled
+        task_graph_details()
+        mkdir_p(File.join(system_config.out_dir,'graphs'),:verbose=>false)
+        save File.join(system_config.out_dir,'graphs',"gaudi"), "png"
+      end#graph
+    end
+
+    def task_graph_details
+      grouped_by_namespace={}
+      no_filetasks=Rake::Task.tasks.select{|rt| rt.class==Rake::Task}
+      no_filetasks.each do |rt|
+        name_parts=rt.name.split(":").reverse
+        if name_parts.size>1
+          name_space=name_parts.pop
+        else
+          namespace=""
+        end
+        grouped_by_namespace[name_space]||=[]
+        grouped_by_namespace[name_space]<<rt.name
+        rt.prerequisites.each{|prereq| edge rt.name,prereq}
+      end
+      grouped_by_namespace.each do |k,v|
+        cluster k do
+          v.each{|ar| node(ar)}
+        end
+      end
+    end
+  end
+end

--- a/lib/gaudi/tasks/doc.rb
+++ b/lib/gaudi/tasks/doc.rb
@@ -1,8 +1,17 @@
 require 'rdoc'
+
 RDoc::Task.new(:rdoc=>"doc:gaudi", :clobber_rdoc => "clean:doc:gaudi",:rerdoc=>"doc:gaudi:force") do |rdoc|
   rdoc.title= "Build System"
   rdoc.rdoc_files.include("#{$configuration.base}/doc/BUILDSYSTEM.md", "#{$configuration.base}/Tools/build/lib/**/*.rb")
   rdoc.rdoc_dir=File.join($configuration.out,"doc/gaudi")
   rdoc.main="BUILDSYSTEM.md"
   rdoc.options+=["--page-dir=#{$configuration.base}/doc","-O"]
+end
+
+namespace :doc do 
+  desc "Generates a dependency graph for all tasks in scope grouped by namespace under #{$configuration.out}/graphs"
+  task :"graph:gaudi" do 
+    include Gaudi::Documentation
+    task_graph($configuration)
+  end
 end

--- a/lib/gaudi/version.rb
+++ b/lib/gaudi/version.rb
@@ -6,7 +6,7 @@ module Gaudi
     #Major version
     MAJOR=1
     #Minor version
-    MINOR=0
+    MINOR=1
     #Tiny version
     TINY=0
     #All-in-one


### PR DESCRIPTION
Adds doc:graph:gaudi to generate a dot graph of all available tasks as documentation.

To keep it under control it will filter out all file tasks.