### PR TITLE
Doc/enhance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,62 @@
-# Gaudi - A Builder [![CircleCI](https://circleci.com/gh/damphyr/gaudi/tree/main.svg?style=svg)](https://circleci.com/gh/damphyr/gaudi/tree/main) [![Coverage Status](https://coveralls.io/repos/damphyr/gaudi/badge.png)](https://coveralls.io/r/damphyr/gaudi) [![Code Climate](https://codeclimate.com/github/damphyr/gaudi.png)](https://codeclimate.com/github/damphyr/gaudi) [![doc status](http://inch-ci.org/github/damphyr/gaudi.svg?branch=master)](http://inch-ci.org/github/damphyr/gaudi)
+# gaudi - A Builder [![CircleCI](https://circleci.com/gh/damphyr/gaudi/tree/main.svg?style=svg)](https://circleci.com/gh/damphyr/gaudi/tree/main) [![Coverage Status](https://coveralls.io/repos/damphyr/gaudi/badge.png)](https://coveralls.io/r/damphyr/gaudi) [![Code Climate](https://codeclimate.com/github/damphyr/gaudi.png)](https://codeclimate.com/github/damphyr/gaudi) [![doc status](http://inch-ci.org/github/damphyr/gaudi.svg?branch=master)](http://inch-ci.org/github/damphyr/gaudi)
 
-gaudi is not a gem, or a library. It is an approach to constructing build systems for highly complex projects that incorporate multiple technologies, languages and tools.
+gaudi is not a gem or a library. It is an approach for the construction of build
+systems for highly complex projects that incorporate multiple technologies,
+languages and toolchains.
 
 ## Goals
 
-The main goals for Gaudi are:
+The main goals of gaudi are:
 
-* Provide a simple, centralized way for configuring a development environment beginning with the build process
-* Codify a set of conventions for projects targeting multiple platforms.
-* Form the basis for a consistent CLI interface between the developers and the development environment
+* Provision of a simple and centralized way for configuring a development
+  environment beginning with the build process
+* Codification of a set of conventions for projects targeting multiple platforms
+* Formation of a basis for a consistent CLI interface between the developers and
+  the development environment
 
-The approach is layed out in more detail in the [documentation](doc/BUILDSYSTEMS.md)
+The approach and utilization of gaudi are laid out in more detail in the
+[documentation](doc/README.md) directory and the files contained therein.
 
 ## Getting started
 
-This repository hosts the core gaudi code and gaudi-c, the C/C++ building module.
+This repository hosts the core gaudi code and the _gaudi-c_ module, a module for
+building C/C++.
 
-Gaudi is meant to be a part of you code repository from the initial commit. To that purpose there is a gaudi gem that simplifies the process of integrating gaudi and repo.
+gaudi is meant to be part of a code repository from the initial commit on. To
+that purpose there is a gaudi gem that simplifies the process of integrating
+gaudi in a repository.
 
-Install the gaudi gem:
+The gaudi gem can be installed through the _gem_ command:
 
 ```gem install gaudi```
 
-Create the project scaffold:
+Afterwards a project scaffold can be created with the following command:
 
 ```gaudi -s gaudi_project```
 
-This will create a basic project structure and pull the current version of gaudi from the repo. The scaffold also adds the correct files and structure to support features like the [documentation tasks](doc/DOCUMENTATION.md)
+This command invocation will create a basic project structure and pull the
+current version of gaudi from its upstream repository. The scaffold also adds
+the correct files and structure to support features like the
+[documentation tasks](doc/DOCUMENTATION.md)
 
-Add the gaudi-c module:
+The _gaudi-c_ module can be added to an existing gaudi build system scaffolding
+by utilizing the below invocation of gaudi:
 
 ```gaudi -l gaudi-c https://github.com/damphyr/gaudi.git gaudi_project```
 
 ## Gaudi?
 
-Well, if you know who [Gaudi](http://en.wikipedia.org/wiki/Antoni_Gaud%C3%AD) was you should concentrate on the fact that he rarely produced detailed plans of his works, he created models.
+Well, if you know who [Gaudi](http://en.wikipedia.org/wiki/Antoni_Gaud%C3%AD) was you should concentrate on the fact that he rarely produced detailed plans of his works, instead he created models.
 
-Gaudi was very much a builder and a craftsman, each of his buildings unique yet based on his knowledge of the materials and the techniques for working with them.
+Gaudi was very much a builder and a craftsman. Each of his buildings is unique
+yet based on his knowledge of the materials and the techniques for working with
+them.
 
 ## LICENSE
 
 (The MIT License)
 
-Copyright (c) 2013-2020 Vassilis Rizopoulos
+Copyright (c) 2013-2021 Vassilis Rizopoulos
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/doc/ASPIRATIONS.md
+++ b/doc/ASPIRATIONS.md
@@ -1,13 +1,16 @@
 # A List of Whishes
 
-"In theory, there is no difference between theory and praxis. In praxis, there is"
+"In theory, there is no difference between theory and praxis. In praxis, there
+is"
 
-Consider the following aphorisms as the theory.
+Consider the following aphorisms as the theory the design of gaudi is based
+upon.
 
 ## Just the Repository
 
 * I will be able to recreate my software with just the repository
-* I will be able to recreate my software development environment with just the repository
+* I will be able to recreate my software development environment with just the
+  repository
 * I will be able to run my software with just the repository
 * I will be able to test my software with just the repository
 
@@ -22,12 +25,14 @@ Consider the following aphorisms as the theory.
 
 ## Out of Source Builds
 
-* Artifacts created by the build system are separate from the sources we use to create them
-* No build artifact is commited to the repository. Ever.
+* Artifacts created by the build system are separate from the sources we use to
+  create them
+* No build artifact is committed to the repository. Ever.
 
 ## Breadcrumbs everywhere
 
-* At any point in time I am able to exactly reproduce the commands up to that point
-* I have a record or every command executed by the system
+* At any point in time I am able to exactly reproduce the commands up to that
+  point
+* I have a record of every command executed by the system
 
 also known as [Ariadne's thread](https://en.wikipedia.org/wiki/Ariadne%27s_thread_(logic))

--- a/doc/ASPIRATIONS.md
+++ b/doc/ASPIRATIONS.md
@@ -36,3 +36,7 @@ upon.
 * I have a record of every command executed by the system
 
 also known as [Ariadne's thread](https://en.wikipedia.org/wiki/Ariadne%27s_thread_(logic))
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/BUILDSYSTEMS.md
+++ b/doc/BUILDSYSTEMS.md
@@ -1,42 +1,58 @@
 # Builders, Systems and Management
 
-gaudi is the code substrate supporting a very specific approach to building software systems. 
+gaudi is a code substrate supporting a very specific approach to building
+software systems.
 
-We call it a Builder. It is there to help you create a Build System.
+The developers of gaudi call it a _Builder_. It is there to aid the creation of
+a _Build System_.
 
-We also make a point in distinguishing between Build Systems and Build *Management* Systems:
+Its developers also make a point in distinguishing between _Build Systems_ and
+_Build **Management** Systems_:
 
-A **build system** performs transformations in sequence according to a predetermined dependency chain to create artifacts. A subset of this is the compilation of sources to binaries.
+A **build system** performs transformations in sequence according to a
+predetermined dependency chain to create artifacts. A subset of this can be the
+compilation of source files to binaries.
 
-A **build management system** coordinates build system(s)
+A **build management system** coordinates build system(s).
 
-Using less hairy language:  
+Expressing it in less hairy language: the _makefile_ is the build system, _make_
+is the builder and [Jenkins](https://www.jenkins.io) is the build management
+system.
 
-The makefile is the build system, make is the builder and Jenkins is the build management system.
-
-In our case, gaudi is the builder's tools and rake is the builder.
+In the case of gaudi, gaudi is the builder's tools and rake is the builder.
 
 ## One System to Build Them All
 
-The build system you are meant to create with gaudi goes far beyond the traditional "compile and link" constructs we're used too.
+A build system meant to be created with gaudi goes far beyond the traditional
+"compile and link" constructs the term "build system" usually refers to.
 
-It is meant to provide a consistent command line interface to every task and operation required in the development of your software with the express focus on making automated use easier.
+gaudi is meant to provide a consistent commandline interface to every task and
+operation required in the development of a complex software project with the
+express focus on making automated use easier.
 
-The underlying principles for such a system are [described elsewhere](ASPIRATIONS.md)
+The underlying principles for such a system are described by a set of
+[aphorisms](ASPIRATIONS.md).
 
-The areas of responsibility for such a system can be categorized with labels like "build", "test", "deploy" but this becomes much easier if we colour code it and add some pictures:
+The areas of responsibility for such a system can be categorized with labels
+like "build", "test" and "deploy" but this becomes much easier if these are
+colour coded and added to a picture:
 
 ![Areas of Responsibility](/doc/images/BuildSystem.png)
 
-How do you create such an omniscient system?
+How can such an omniscient system be created?
 
-## Standing on the shoulders of giants
+## Standing on The Shoulders of Giants
 
-Basically do not try to implement everything from scratch. 
+The basic principle is to try not to implement everything from scratch.
 
-Do you want to use asciidoc for documentation? 
-Use the available application for your platform and use gaudi to codify its usage in your project. 
+Shall [AsciiDoc](https://asciidoc.org) be used for documentation? 
+The available application for the needed platform can be used and integrated
+into the gaudi based buildsystem to codify its usage in the project.
 
-The only constraint is that the chosen technology offers a command line tool with a reasonable way of signaling errors (i.e. the program's exit code).
+The only constraint for technologies or toolchains that shall be integrated into
+a gaudi based build system is that the chosen technology or toolchain offers a
+commandline tool with a reasonable way of signaling errors (i.e. the program's
+exit code).
 
-[And so it begins](WALKTHROUGH.md)
+A [walkthrough](WALKTHROUGH.md) on setting up and utilizing gaudi based build
+system is available within this repository too.

--- a/doc/BUILDSYSTEMS.md
+++ b/doc/BUILDSYSTEMS.md
@@ -56,3 +56,7 @@ exit code).
 
 A [walkthrough](WALKTHROUGH.md) on setting up and utilizing gaudi based build
 system is available within this repository too.
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -115,3 +115,7 @@ mixups.
 
 <hr/>
 <sup>1</sup> For given values of typical that might differ from everybody else's
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -1,88 +1,117 @@
-# Gaudi Configuration
+# gaudi Configuration
 
-Configuration is the core feature of Gaudi. The core problem Gaudi is solving is how to get all the parameters for all the tools in one place in a sufficiently flexible format to allow for the permutations needed in a typical project<sup>1</sup>.
+Configuration is the core feature of gaudi. The core problem gaudi is solving is
+how to get all the parameters for all the tools in one place in a sufficiently
+flexible format to allow for the permutations needed in a typical
+project<sup>1</sup>.
 
-Core to Gaudi's development environment control approach is to have the configuration in one place in a versionable, diffable format and a consistent usage interface. The latter is provided by rake, here we will address the configuration part.
+Core to the development environment control approach of gaudi is to have the
+configuration in one place in a versionable, diffable format and accessible
+through a consistent usage interface. The latter is provided by rake. In this
+file the configuration part will be addressed.
 
-## Configuration files
+## Configuration Files
 
-Everything starts with the system configuration file. If you didn't mess with the default values (and if you are reading this, you didn't) the system configuration file is in tools/build/system.cfg
+Everything starts with the system configuration file. If the default values were
+not modified the system configuration file resides in `tools/build/system.cfg`
+(relative to the root of the repository of the project built by gaudi).
 
 For the core gaudi functionality the configuration is very simple:
 
 ```text
-#the project root directory
+# the project root directory
 base=../../
-#the build output directory
+# the build output directory
 out=../../out
 ```
 
-## Configuration format
+## Configuration Format
 
-Gaudi uses a very simple configuration format (even though the underlying implementation has proven rather elaborate). Basically it's the property=value format with a few embelishments:
+gaudi uses a very simple configuration format (even though the underlying
+implementation has proven to be rather elaborate). Basically it's a `property=value`
+format with a few embellishments:
 
 ```bash
-#setenv allows you to set environment variables to be used within rake
+# setenv allows to set environment variables to be used within rake
 setenv FOO=bar
-#import allows you to break up the configuration across several files and compose it
+# import allows to break up the configuration across several files and compose it
 import ./extra_options.cfg
 ```
 
-Property values can use earlier defined properties as variables within their value with a simple percentage syntax. Example:
+Property values can use earlier defined properties as variables within their
+value with a simple percentage sign syntax. Example:
 
 ```bash
 # Set some properties
 appname=MyApplication
 version_major=1
 version_minor=3
-# Use already defined properties within other properties
+# Use the already defined properties within other properties
 version_string=%{appname} %{version_major}.%{version_minor}
 ```
 
-This will also work when reassigning the value of an already existing property. Example
+This will also work when reassigning the value of an already existing property.
+Example:
 
 ```bash
 path=/bin;/usr/bin;/usr/local/bin
-# prepend something to path
+# Prepend something to path
 path=/home/myuser/bin;%{path}
 ```
 
-Extending the available configuration properties is done by adding modules to Gaudi::Configuration::SystemModules (for more details check [EXTENDING](EXTENDING.md))
+An extension of the available configuration properties is done by adding
+respective modules to `Gaudi::Configuration::SystemModules` (for more details
+check [EXTENDING](EXTENDING.md)).
 
-### Precedence order
+### Precedence Order
 
-Usage of import raises the issue of what happens when a parameter is defined in several files.
+The availability and usage of `import` raises the issue of what happens when a
+parameter is defined in several files.
 
-Gaudi has a simple precedence system: Last one wins.
+Gaudi has a simple precedence system: The last one wins.
 
 ### Environment Variables
 
-rake allows you to define an environment variable on the command line:
+rake allows to define environment variables on the command line:
 
 ```bash
 rake task FOO=bar
 ```
 
-Gaudi supports a set of environment variables as a way for passing options and exposes these as attributes of the system configuration
+Gaudi supports a set of environment variables as a way for passing options and
+exposes these as attributes of the system configuration
 
-* GAUDI_CONFIG - points to the configuration file.
-* USER - passes the user name
+* `GAUDI_CONFIG` - points to the configuration file.
+* `USER` - passes the user name
 
-Adding methods to Gaudi::Configuration::EnvironmentOptions is the recommended way to expose environment variables to Gaudi. This is pure convention but results in pulling the documentation of environment options together in one rdoc page. It also allows us to have parsing, validation and sanitization of input in one place.
+Adding methods to `Gaudi::Configuration::EnvironmentOptions` is the recommended
+way to expose environment variables to gaudi. This is pure convention but
+results in pulling the documentation of environment options together in one RDoc
+page. It also allows to have parsing, validation and sanitization of input in
+one place.
 
-In some cases there are two versions of the reader method for the environment variables. The bang version (i.e. user! ) will raise a GaudiConfigurationError if the requested value is nil or the empty string. When there is only one version the current choice is to raise the exception by default. 
+In some cases there are two versions of the reader method for an environment
+variable. The bang version (i.e. `user!`) will raise a `GaudiConfigurationError`
+if the requested value is `nil` or an empty string. When there is only one
+version the current choice is to raise the exception by default.
 
 ## System Configuration
 
-The standard configuration parameters out-of-the-box are
+The standard out-of-the-box configuration parameters are
 
-* base - the root directory of the project. Usually where the rakefile is.
-* out - the build output directory.
-* gaudi_modules - the comma separated list of modules to require when loading gaudi
+* `base` - the root directory of the project. Usually where the rakefile is
+* `out` - the build output directory
+* `gaudi_modules` - the comma separated list of modules to require when loading
+  gaudi
 
-**All paths in the configuration can be defined absolute or relative to the configuration file.**
+**All paths in the configuration can be defined absolute or relative to the
+configuration file they are defined in.**
 
-Defining _base_ relative to the configuration file has the added advantage of making the whole configuration portable to different branches. Generally avoid absolute paths for anything that is in your project's repository, Gaudi will expand all paths to their absolute values to avoid mixups.
+Defining `base` relative to the configuration file has the added advantage of
+making the whole configuration portable to different branches. Generally
+absolute paths should be avoided for anything that is within the project's
+repository, gaudi will expand all paths to their absolute values to avoid
+mixups.
 
 <hr/>
 <sup>1</sup> For given values of typical that might differ from everybody else's

--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -1,37 +1,48 @@
-# gaudi documentation features
+# gaudi Documentation Features
 
-## Gaudi library documentation
+## gaudi Library Documentation
 
-```rake doc:gaudi```
+Since both rake and gaudi are Ruby code there is a built-in facility for
+generating [RDoc](https://ruby.github.io/rdoc) documentation.
 
-Since rake and gaudi is Ruby code there is a built-in facility for generating RDoc documentation.
+The `doc:gaudi` rake task will automatically generate the reference
+documentation for the build system code under `system_config.out/doc/gaudi`.
 
-The `doc:gaudi` task will automatically generate the reference documentation for the build system code under `system_config.out/doc/gaudi`.
-
-It uses doc/BUILDSYSTEM.md as the main page, a file that is created when using the gaudi gem to scaffold a project.
+It uses `doc/BUILDSYSTEM.md` as the main page, a file that is created when using
+the gaudi gem to scaffold a project.
 
 ## Graphs
 
-Gaudi is meant to cover all responsibility areas of an extended build system (as [explained elsewhere](BUILDSYSTEMS.md)).
+gaudi is meant to cover all responsibility areas of an extended build system (as
+[explained elsewhere](BUILDSYSTEMS.md)).
 
 ![Areas of Responsibility](/doc/images/BuildSystem.png)
 
-On a mature system the number of tasks can quickly become overwhelming. To manage it better gaudi provides a task to create graphs (using the [graphviz dot format](http://www.graphviz.org/doc/info/lang.html) and the [graph](https://github.com/seattlerb/graph) gem)
+On a mature build system the number of tasks can quickly become overwhelming. To
+improve the management of these gaudi provides a task to create graphs of these
+and their dependencies (using the
+[graphviz dot format](http://www.graphviz.org/doc/info/lang.html) and the
+[graph](https://github.com/seattlerb/graph) gem).
 
-Use ```rake doc:graph:gaudi``` to create the diagram (as `system_config.out/doc/graphs/gaudi.png`).
+`rake doc:graph:gaudi` can be used to create the diagram (as
+`system_config.out/doc/graphs/gaudi.png`).
 
-One organizational measure is to group tasks by namespace. If you use the following responsibility-to-namespace mapping you will get colours in the generated graph matching the colours in the overview image.
+One organizational measure is to group the build system's tasks by namespaces.
+If the following responsibility-to-namespace mapping is utilized, then the
+colours in the generated graph will match the colours of the overview image.
 
 |Area|Namespace|
 |----|----|
-|Generate|gen|
-|Build|build|
-|Static Analysis|lint|
-|Unit Testing|unit|
-|Package|pkg|
-|Deployment|deploy|
-|Test|test|
+|Generate|`gen`|
+|Build|`build`|
+|Static Analysis|`lint`|
+|Unit Testing|`unit`|
+|Package|`pkg`|
+|Deployment|`deploy`|
+|Test|`test`|
 
-In addition the `doc` namespace is assigned the brown variant in the colour scheme
+In addition the `doc` namespace is assigned the brown variant in the colour
+scheme.
 
-The colour pallete used is [Brewer scheme Set 1 of 9-class](http://colourbrewer2.org/#type=qualitative&scheme=Set1&n=9) 
+The colour pallete used is
+[Brewer scheme Set 1 of 9-class](http://colourbrewer2.org/#type=qualitative&scheme=Set1&n=9).

--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -46,3 +46,7 @@ scheme.
 
 The colour pallete used is
 [Brewer scheme Set 1 of 9-class](http://colourbrewer2.org/#type=qualitative&scheme=Set1&n=9).
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/EXTENDING.md
+++ b/doc/EXTENDING.md
@@ -1,35 +1,51 @@
-# Extending Gaudi
+# Extending gaudi
 
-Which is to say, making the thing usable.
+This guide describes how to add actual functionality like code generation,
+compilation, deployment and so forth to a build system based on gaudi.
 
 ## Integrating custom code
 
-It is **very strongly** advised to organize you gaudi based code in one or more [gaudi modules](MODULES.md) and to not add anything under lib/gaudi/.
+It is **very strongly** advised to organize gaudi based code in one or more
+[gaudi modules](MODULES.md) and to not add anything under `lib/gaudi` directly.
 
-Create a directory parallel to tools/build/lib/gaudi and follow the gaudi module structure:
+New modules should be created in directories parallel to `tools/build/lib/gaudi`
+and follow the structure of the gaudi module:
 
-lib/
-  |-gaudi/
-  |-module/
-      |-helpers/
-      |-tasks/
-  |-gaudi.rb
+    lib/
+      |-gaudi/
+          |-helpers/
+          |-tasks/
+      |-<gen_mod>/
+          |-helpers/
+          |-tasks/
+      |-<build_mod>/
+          |-helpers/
+          |-tasks/
+      |-<deploy_mod>/
+          |-helpers/
+          |-tasks/
+      |-gaudi.rb
 
-Don't mix tasks and helpers, the load sequence ensures that all code in the helpers/ directory is available before loading any tasks.
+Helpers and tasks may not be mixed. The load sequence ensures that all code in
+the `helpers/` directory is available before loading any tasks so that these can
+rely on the helpers' functionality.
 
-To activate you custom code add to the sytem configuration:
+To activate custom modules these have to be added to the system configuration:
 
 ```text
-gaudi_modules=module
+gaudi_modules=gen_mod,build_mod,deploy_mod
 ```
 
-For maximum reuse the [module concept](MODULES.md) allows us to reuse custom code from a git repo.
+For maximum reuse the [module concept](MODULES.md) allows to reuse custom code
+from a Git repository.
 
-Also, you probably want to follow the [gaudi style](STYLE.md) so that custom code and core are consistent to the eye.
+Additionally new modules should follow the [gaudi style](STYLE.md) so that
+custom modules' code and the gaudi core code are consistent.
 
 ## Rakefiles
 
-You only need one rakefile at the root of your repository (assuming a standard directory structure) and it looks like the following:
+At the root of the repository (assuming a standard directory structure) there
+should be one central rakefile and it should look like the following:
 
 ```ruby
 require_relative 'tools/build/lib/gaudi'
@@ -37,46 +53,59 @@ env_setup(File.dirname(__FILE__))
 require_relative 'tools/build/lib/gaudi/tasks'
 ```
 
-If you use the gaudi gem to scaffold your project then the Rakefile is already there.
+If the gaudi gem is used to scaffold a project, then the rakefile is already
+there.
 
 ## Configuration
 
-One of gaudi's core goals is to centralize configuration in a readable, diffable and versionable format. Consequently we need a way to add new parameters to the configuration files.
+One of gaudi's core goals is to centralize the build system configuration in a
+readable, diffable and versionable format. Consequently a way to add new
+available options/parameters to the configuration files is needed.
 
-This is done using Ruby modules with a naming convention:
+This is realized by using Ruby modules with a naming convention:
 
 ```ruby
-module Gaudi::Configuration::SystemModules::MoarConfig
+module Gaudi::Configuration::SystemModules::ConfigOptionsExtension
   def self.list_keys
-    ['moar_list']
+    ['new_list_option']
   end
+
   def self.path_keys
-    ['moar_path']
+    ['new_path_option']
   end
-  def moar_list
-    @config['moar_list']
+
+  def new_list_option
+    @config['new_list_option']
   end
-  #An accessor/reader method that will be available from the system configuration object.
+
+  # An accessor/reader method that will be available from the system
+  # configuration object.
   #
-  #Also a conveniently central place for input validation, syntax checking, default value setting etc.
-  def moar_path
-    return required_path(@config['moar_path'])
+  # Also a conveniently central place for input validation, syntax checking,
+  # default value setting etc.
+  def new_path_option
+    return required_path(@config['new_path_option'])
   end
 end
 ```
 
-*path_keys* and *list_keys* are simple arrays of the parameter names that tell gaudi to handle these parameters in a special way.
+`list_keys` and `path_keys` are simple arrays of parameter names that make gaudi
+handle these parameters in special ways:
 
-When in *path_keys* then the value of the parameter is treated as a path and expanded to it's absolute value
+* *list_keys* makes the value of the parameter being assumed to be a comma
+  separated list of values and is being parsed into an Array
+* *path_keys* let's the value of the parameter being treated as a path and being
+  expanded to it's absolute value upon its retrieval
 
-When in *list_keys* then the value of the parameter is assumed to be a comma separated list of values and is parsed into an Array.
+`required_path` is an additional helper method that will raise an error if the
+passed path is missing. `Gaudi::Configuration::Helpers` is a module which
+contains all methods used for validation, convenience and so forth.
 
-*required_path* is a helper method that will raise an error if the path is missing. Gaudi::Configuration::Helpers contains all methods used for valdation, convenience etc.
-
-The methods are available as methods of the gaudi system configuration instance. So within a task you can do 
+The methods are available as methods of the gaudi system configuration instance.
+So within a task
 
 ```ruby
-$configuration.moar_path
+$configuration.new_path_option
 ```
 
-to access the configuration value.
+can be called to access the configuration value.

--- a/doc/EXTENDING.md
+++ b/doc/EXTENDING.md
@@ -109,3 +109,7 @@ $configuration.new_path_option
 ```
 
 can be called to access the configuration value.
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/MODULES.md
+++ b/doc/MODULES.md
@@ -44,3 +44,7 @@ gaudi -l foo https://module.source/foo.git my_project
 
 So reusable generic code can be kept in a separate repository and be shared
 between projects.
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/MODULES.md
+++ b/doc/MODULES.md
@@ -1,34 +1,46 @@
-# Gaudi modules
+# gaudi Modules
 
-The modules concept allows us to add code to gaudi installations from multiple sources and have it be required and integrated in the way that gaudi core expects.
+The concept of gaudi modules allows to add code to gaudi installations from
+multiple sources and to have it being required and integrated in the way that
+gaudi core expects.
 
 A "gaudi module" has a fixed directory structure:
 
-* helpers - a directory for library code. All .rb files here are automatically required during the configuration process
-* tasks - a directory for rake tasks. All files here are automatically required after gaudi is configured. All helpers are guaranteed to already be required at this stage.
+* `helpers` - a directory for library code. All `.rb` files in there are
+  automatically required during the configuration loading process
+* `tasks` - a directory for rake tasks. All files here are automatically
+  required after gaudi is configured. All helpers are guaranteed to already be
+  required at this stage.
 
-## Using modules
+## Utiliztation Of Modules In A gaudi Managed Build System
 
-* Create a directory under tools/build/lib and name it after your module.
-* Place files in the appropriate subfolders.
-* Add the module to the system configuration
+* A directory named after the new module is to be created under
+  `tools/build/lib`
+* Ruby files declaring new tasks and their helpers are to be placed into the
+  appropriate subfolders of the new module
+* Lastly the new module has to be added to the system configuration
 
-In the system configuration file add the following:
+The new module has to be added to the `gaudi_modules` variable within the system
+configuration as follows:
 
 ```text
-gaudi_modules= my_module
+gaudi_modules=some_c_module,a_csharp_module,ci_module,the_newly_added_module
 ```
 
-This instructs gaudi to look in lib/my_module and incorporate the helpers and tasks it finds.
+This instructs gaudi to look in `lib/the_newly_added_module` directory and
+incorporate the helpers and tasks it finds within it.
 
-## Managing modules
+## Managing Modules
 
 The gaudi gem offers a way to download/update modules from git repositories.
 
-The git repository needs to mirror the structure of gaudi core (a lib/module_name directory)
+The git repository needs to mirror the structure of gaudi core (a
+`lib/module_name` directory). It then can be added to an existing project as
+follows:
 
 ```bash
 gaudi -l foo https://module.source/foo.git my_project
 ```
 
-So you can keep your super-extra-reusable-generic-code in a separate repository and share between projects.
+So reusable generic code can be kept in a separate repository and be shared
+between projects.

--- a/doc/README.md
+++ b/doc/README.md
@@ -8,7 +8,8 @@ implementation as well as the utilization of gaudi.
 * [Builders, Systems and Management](BUILDSYSTEMS.md) - explanation of the
   concepts behind build systems, build system builds and build management
   systems
-* [gaudi Configuration](CONFIGURATION.md)
+* [gaudi Configuration](CONFIGURATION.md) - how gaudi and and the build system
+  built with it can be configured
 * [gaudi Documentation Features](DOCUMENTATION.md)
 * [Extending gaudi](EXTENDING.md)
 * [gaudi modules](MODULES.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,7 +17,7 @@ implementation as well as the utilization of gaudi.
 * [gaudi modules](MODULES.md) - the concept of gaudi modules for a standardized
   and reusable extension of gaudi managed build systems with
   common functionality
-* [Reasonings](REASONINGS.md)
+* [Reasonings](REASONINGS.md) - rationale of the abstination from packaging gaudi as a gem
 * [The gaudi Coding Style](STYLE.md) - generic coding conventions for projects
   based on gaudi
 * [gaudi Walkthrough](WALKTHROUGH.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,8 @@
 This directory contains documentation files for the philosophy, design and
 implementation as well as the utilization of gaudi.
 
-* [Aspirations](ASPIRATIONS.md)
+* [Aspirations](ASPIRATIONS.md) - basic aphorisms representing basic principles
+  which the design of gaudi is based upon
 * [Builders, Systems and Management](BUILDSYSTEMS.md)
 * [gaudi Configuration](CONFIGURATION.md)
 * [gaudi Documentation Features](DOCUMENTATION.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,5 +17,6 @@ implementation as well as the utilization of gaudi.
   and reusable extension of gaudi managed build systems with
   common functionality
 * [Reasonings](REASONINGS.md)
-* [The gaudi Coding Style](STYLE.md)
+* [The gaudi Coding Style](STYLE.md) - generic coding conventions for projects
+  based on gaudi
 * [gaudi Walkthrough](WALKTHROUGH.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,7 +12,8 @@ implementation as well as the utilization of gaudi.
   built with it can be configured
 * [gaudi Documentation Features](DOCUMENTATION.md) - documentation facilities of
   gaudi in support of large build systems
-* [Extending gaudi](EXTENDING.md)
+* [Extending gaudi](EXTENDING.md) - how to build and extend the functionality of
+  a build system based on gaudi
 * [gaudi modules](MODULES.md) - the concept of gaudi modules for a standardized
   and reusable extension of gaudi managed build systems with
   common functionality

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,14 @@
+# README
+
+This directory contains documentation files for the philosophy, design and
+implementation as well as the utilization of gaudi.
+
+* [Aspirations](ASPIRATIONS.md)
+* [Builders, Systems and Management](BUILDSYSTEMS.md)
+* [gaudi Configuration](CONFIGURATION.md)
+* [gaudi Documentation Features](DOCUMENTATION.md)
+* [Extending gaudi](EXTENDING.md)
+* [gaudi modules](MODULES.md)
+* [Reasonings](REASONINGS.md)
+* [The gaudi Coding Style](STYLE.md)
+* [gaudi Walkthrough](WALKTHROUGH.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -13,7 +13,9 @@ implementation as well as the utilization of gaudi.
 * [gaudi Documentation Features](DOCUMENTATION.md) - documentation facilities of
   gaudi in support of large build systems
 * [Extending gaudi](EXTENDING.md)
-* [gaudi modules](MODULES.md)
+* [gaudi modules](MODULES.md) - the concept of gaudi modules for a standardized
+  and reusable extension of gaudi managed build systems with
+  common functionality
 * [Reasonings](REASONINGS.md)
 * [The gaudi Coding Style](STYLE.md)
 * [gaudi Walkthrough](WALKTHROUGH.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -20,4 +20,5 @@ implementation as well as the utilization of gaudi.
 * [Reasonings](REASONINGS.md) - rationale of the abstination from packaging gaudi as a gem
 * [The gaudi Coding Style](STYLE.md) - generic coding conventions for projects
   based on gaudi
-* [gaudi Walkthrough](WALKTHROUGH.md)
+* [gaudi Walkthrough](WALKTHROUGH.md) - a minimal walkthrough on the creation of
+  a gaudi module

--- a/doc/README.md
+++ b/doc/README.md
@@ -22,3 +22,7 @@ implementation as well as the utilization of gaudi.
   based on gaudi
 * [gaudi Walkthrough](WALKTHROUGH.md) - a minimal walkthrough on the creation of
   a gaudi module
+
+---
+
+Back to the [root README](../README.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,7 +5,9 @@ implementation as well as the utilization of gaudi.
 
 * [Aspirations](ASPIRATIONS.md) - basic aphorisms representing basic principles
   which the design of gaudi is based upon
-* [Builders, Systems and Management](BUILDSYSTEMS.md)
+* [Builders, Systems and Management](BUILDSYSTEMS.md) - explanation of the
+  concepts behind build systems, build system builds and build management
+  systems
 * [gaudi Configuration](CONFIGURATION.md)
 * [gaudi Documentation Features](DOCUMENTATION.md)
 * [Extending gaudi](EXTENDING.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,8 @@ implementation as well as the utilization of gaudi.
   systems
 * [gaudi Configuration](CONFIGURATION.md) - how gaudi and and the build system
   built with it can be configured
-* [gaudi Documentation Features](DOCUMENTATION.md)
+* [gaudi Documentation Features](DOCUMENTATION.md) - documentation facilities of
+  gaudi in support of large build systems
 * [Extending gaudi](EXTENDING.md)
 * [gaudi modules](MODULES.md)
 * [Reasonings](REASONINGS.md)

--- a/doc/REASONINGS.md
+++ b/doc/REASONINGS.md
@@ -36,3 +36,7 @@ process (rather ironic for a tool whose goal is to automate stuff).
 
 The [extending gaudi](EXTENDING.md) section can be checked for code that adds
 functionality past the core compilation and build stages.
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/REASONINGS.md
+++ b/doc/REASONINGS.md
@@ -1,15 +1,38 @@
 # Reasonings
 
-While the parts of Gaudi that are published deal with building C/C++ programs, project specific applications include static code analysis, IDE project generation, documentation generation, test execution, reporting and release management and more or less every task you could automate in a software project.
+While the parts of Gaudi that are published to deal with building C/C++
+programs, project specific applications including static code analysis, IDE
+project generation, documentation generation, test execution, reporting and
+release management and more or less every task can be automated in a software
+project.
 
-Experience shows that even if you narrow down the scope (to say embedded C projects for very constrained devices) every project develops differently. The decision to avoid publishing a gem is based on this fact and a usage scenario as it developed over several years of using rake to build embedded systems.
+Experience shows that even if the scope is narrowed down greatly (like so to say
+in embedded C projects for very constrained devices) every project develops
+differently. The decision to abstain from publishing a gaudi gem is based on
+this fact and usage scenario as gaudi developed over several years of using rake
+to build embedded systems.
 
-Basically the build system is versioned within the project repository and does not need the extra versioning layer a gem provides. The speed of propagating  build system changes in a project under heavy development is much more important - a git pull should suffice. Also bundling as a gem introduces a disconnect between the version that is committed and the version that is installed in the development environment with sometimes unnerving consequences.
+Basically the build system is versioned within the project repository and does
+not need the extra versioning layer a gem provides. The speed of propagating
+build system changes in a project under heavy development is much more
+important - a git pull should suffice. Also bundling as a gem introduces a
+disconnect between the version that is committed and the version that is
+installed in the development environment with sometimes unnerving consequences.
 
-Having said that, you do need a plan for managing the inevitable cornucopia of gems that will be used in implementing tasks.
+Having said that, a plan is needed for managing the inevitable cornucopia of
+gems that will be used in implementing the tasks and their helpers.
 
-One of the benefits of Gaudi is that it provides you with all kinds of information about your code base. It is a simple step to add code that for example feeds code metrics to an information radiator for every build. Adding static code analysis is also very easy, as it operates on the same set of files that the [Gaudi objects](HIERARCHY.md) provide.
+One of the benefits of gaudi is that it provides all kinds of information about
+the code base. It is a simple step to add code that for example feeds code
+metrics to an information radiator for every build. Adding static code analysis
+is also very easy, as it operates on the same set of files that the
+[gaudi modules](MODULES.md) provide.
 
-But consistent with the decision not to bundle Gaudi as a gem is the decision to only include in core Gaudi the compile/build abstractions that have proven themselves over several years and across several projects. Even there your mileage may vary so the [usage pattern](EXTENDING.md) for Gaudi is a manual process (rather ironic for a tool whose goal is automating stuff).
+But consistent with the decision not to bundle gaudi as a gem is the decision to
+include in core gaudi only those compilation and build abstractions that have
+proven themselves over several years and across several projects. Even there the
+mileage may vary so the [usage pattern](EXTENDING.md) for gaudi is a manual
+process (rather ironic for a tool whose goal is to automate stuff).
 
-Check the [examples](examples/) section for code that adds functionality past the core compile/build stages.
+The [extending gaudi](EXTENDING.md) section can be checked for code that adds
+functionality past the core compilation and build stages.

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -54,3 +54,7 @@ This allows to easily set defaults in development environment installations and
 has the added benefit of providing reference documentation in one place by
 adding accessors in `Gaudi::Configuration::EnvironmentOptions` (see
 [CONFIGURATION](CONFIGURATION.md) for details).
+
+---
+
+Back to the [README contents](README.md)

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -1,40 +1,56 @@
-# The Gaudi Coding Style
+# The gaudi Coding Style
 
-## System configuration
+## System Configuration
 
-Gaudi exposes the system configuration in a global variable called $configuration.
+gaudi exposes the system configuration in a global variable called
+`$configuration`.
 
-We refer to $configuration **only** within tasks. No gaudi helper module or method should EVER access $configuration directly. The system configuration is always passed to the method as a parameter named system_config.
+`$configuration` is referred to directly **only** within tasks. No gaudi helper
+module or method should **ever** access `$configuration` directly. The system
+configuration is always passed to helper methods that rely on it as a parameter
+named `system_config`.
 
-## Method parameters
+## Method Parameters
 
-Method parameters are defined from specific to generic and the last two are always system_config,platform (when the method is platform independent, then system_config is the last parameter).
+Method parameters are defined from specific to generic and the last two are
+always `system_config` and `platform` (when the method is platform-independent,
+then `system_config` is the last parameter):
 
 ```ruby
-def determine_directories name,source_directories,system_config,platform
-#...
+def determine_directories(name, source_directories, system_config, platform)
+  #...
 end
-def compile filetask,system_config,platform
-#...
+
+def generate(filetask, system_config)
+  #...
+end
+
+def compile(filetask, system_config, platform)
+  #...
 end
 ```
 
 ## Helpers & Tasks
 
-The code is organized in modules and each task includes the modules needed
+The code is organized in modules and each task includes the modules it requires:
 
 ```ruby
-desc "Builds the deployment specified with DEPLOYMENT.\n rake build:deployment DEPLOYMENT=Foo"
+desc "Builds the deployment specified with DEPLOYMENT.\nrake build:deployment DEPLOYMENT=Foo"
 task :deployment do
   include Gaudi::Tasks::Build
-  deployment=Gaudi::Deployment.new($configuration.deployment,$configuration)
-  t=deployment_task(deployment,$configuration)
+
+  deployment = Gaudi::Deployment.new($configuration.deployment, $configuration)
+  t = deployment_task(deployment, $configuration)
   Rake::Task[t].invoke
 end
 ```
 
-## Parametrizing tasks
+## Parametrizing Tasks
 
-Rake allows us to create tasks that accept parameters but in gaudi we chose to use environment variables.
+Rake allows to create tasks that accept parameters but in the case of gaudi it
+was chosen to use environment variables instead.
 
-This allows us to easily set defaults in development environment installations and has the added benefit of providing reference documentation in one place by adding accessors in Gaudi::Configuration::EnvironmentOptions (see [CONFIGURATION](CONFIGURATION.md) for details)
+This allows to easily set defaults in development environment installations and
+has the added benefit of providing reference documentation in one place by
+adding accessors in `Gaudi::Configuration::EnvironmentOptions` (see
+[CONFIGURATION](CONFIGURATION.md) for details).

--- a/doc/WALKTHROUGH.md
+++ b/doc/WALKTHROUGH.md
@@ -1,38 +1,50 @@
-# Gaudi Walkthrough
+# gaudi Walkthrough
 
-Wherein we walk through a limited example as a demonstration of using gaudi to integrate different tools.
+This walkthrough presents a limited example as a demonstration of using gaudi to
+integrate different tools.
 
-Let us assume we have a .NET core application, since this is the usage with the highest dissonance for gaudi.
+A _.NET Core_ application is being used for as exemplary use case for being a
+usage scenario with a very high dissonance for gaudi.
 
-We start by scaffolding our project:
+As a start the scaffolding for the project has to be created:
 
 ```bash
 gaudi -s gaudi_project
 ```
 
-We then add a place for our helpers and tasks:
+Then a new gaudi module for the _.NET_ helpers and tasks is being created with
+its own subdirectories for helpers and tasks:
 
 ```bash
 mkdir -p tools/build/lib/gaudi_net/helpers
 mkdir -p tools/build/lib/gaudi_net/tasks
 ```
 
-and let gaudi know by editing tools/build/system.cfg and adding:
+This new module is then being made known to gaudi by adding it to the
+`gaudi_modules` list in `tools/build/system.cfg`:
 
-```bash
+```text
 gaudi_modules=gaudi_net
 ```
 
-## Command line is king
+## Commandline is king
 
-In this example we're adding a build tool in our build system. We need to figure out where the tool is and how to put together the command line to call it.
-The degree to which this can be abstracted, organized in reusable code modules, validated etc. is entirely up to the individual developer. We're going to keep things really simple to illustrate the points of integration with gaudi.
+In this example a build tool shall be added to the build system. For this it is
+mandatory to figure out where the tool is located and how a commandline
+invocation is to be assembled.
 
-Let us assume we have a consistently provisioned environment and we invoke msbuild with the "dotnet msbuild" command.
+The degree to which this can be abstracted, be organized in reusable code
+modules, be validated etc. is entirely up to the individual developer. This
+walkthrough is deliberately being kept really simple to illustrate the points of
+integration with gaudi. In this example it is being assumed that a consistently
+provisioned environment exists and that `msbuild` is being invoked with the
+`dotnet msbuild` command.
 
-We also have our code organized in the usual solution/projects used in .NET
+The example code is organized in the usual solution/projects as customary in
+_.NET_ development.
 
-Add tools/build/config/dotnet.cfg with the following content:
+A new configuration file `tools/build/config/dotnet.cfg` with the following
+content is to be created:
 
 ```text
 msbuild=dotnet msbuild
@@ -40,50 +52,78 @@ msbuild_options=/nr:false /m
 msbuild_default_options=/p:StyleCopEnabled=false /p:RunCodeAnalysis=false
 ```
 
-and add it to the system configuration (tools/build/system.cfg) by adding
+To come into effect this file has to be included into the overall build system
+configuration by adding
 
 ```text
 import config/msbuild.cfg
 ```
 
-Now add tools/build/lib/gaudi_net/helpers/msbuild.rb:
+to `tools/build/system.cfg`.
+
+Then a `tools/build/lib/gaudi_net/helpers/msbuild.rb` should be created with the
+following content to be able to make use of the new configuration options
+through the global `Gaudi::Configuration::SystemConfiguration` instance.
 
 ```ruby
-#Configuraton options for MSBuild integration
+##
+# Configuraton options for MSBuild integration
 module Gaudi::Configuration::SystemModules::MSBuild
   #:stopdoc:
   def self.list_keys
     []
   end
+
   def self.path_keys
     []
   end
+
   #:startdoc:
-  #Path to the msbuild executable to use
+  ##
+  # Path to the msbuild executable to use
   def msbuild
     @config['msbuild']
   end
-  #Options to pass to MSBuild. Use this for things like /maxcpucount
+
+  ##
+  # Options to pass to MSBuild. Use this for things like /maxcpucount
   def msbuild_options
     @config['msbuild_options']
   end
-  #Options to pass to MSBuild when compiling
+
+  ##
+  # Options to pass to MSBuild when compiling
   def msbuild_default_build_options
     @config['msbuild_default_build_options']
   end
 end
 ```
 
-The code above adds the configuration options to our system configuration object. We then add a simple task by pasting the following in tools/build/lib/gaudi_net/tasks/build.rb. For more details, look in the [configuration docs](CONFIGURATION.md)
+The above file does not need to be restricted to creating configuration options
+but is able to contain any classes, modules or methods which then can be used
+either within other helpers or tasks.
+
+The code above adds the configuration options to the global system configuration
+object. A simple task can then be added by pasting the following in
+`tools/build/lib/gaudi_net/tasks/build.rb`. More details on the usage of
+configuration options can be found in the
+[gaudi configuration documentation](CONFIGURATION.md)
 
 ```ruby
 namespace :build do 
   task :hello do 
-    solution=File.join($configuration.base,"src/HellloWorld.sln")
-    cmdline="#{$configuration.msbuild} #{$configuration.msbuild_options} #{$configuration.msbuild_default_build_options} /p:Configuration=Relase #{solution}"
+    solution = File.join($configuration.base, 'src/HelloWorld.sln')
+    cmdline = "#{$configuration.msbuild} #{$configuration.msbuild_options}" \
+      " #{$configuration.msbuild_default_build_options}" \
+      " /p:Configuration=Relase #{solution}"
     sh(cmdline)
   end
 end
 ```
 
-At this point you should start thinking on how your code is layed out in the repository, how you want to structure your build, look into things like automatically generating assembly information (with things like version metadata that tie to the SHA of your code in the repo) and sharing it across projects etc.
+From this point on the developer should think on how the code should be laid out
+in the repository, across which modules the functionality should be split and
+which configuration options, modules, classes and tasks should make up each of
+them. An example of such functionality could be automatic code generation (e.g.
+version metadata derived from a commit SHA). On an even higher level a possible
+sharing of the code across multiple projects could be considered too.

--- a/doc/WALKTHROUGH.md
+++ b/doc/WALKTHROUGH.md
@@ -127,3 +127,7 @@ which configuration options, modules, classes and tasks should make up each of
 them. An example of such functionality could be automatic code generation (e.g.
 version metadata derived from a commit SHA). On an even higher level a possible
 sharing of the code across multiple projects could be considered too.
+
+---
+
+Back to the [README contents](README.md)


### PR DESCRIPTION
This pull request tries to improve the readability of the documentation and the navigation within it. The styles of the text have been more unified and some statements have been elaborated slightly. The linking between the individual documents was extended.

One change is just a matter of style. In some locations _gaudi_ was spelled as lower case only which gave me the impression that this is maybe the preferred style. On the other hand this differs from the module name in Ruby code, since it's written with a capital `G` there as it's customary for Ruby modules. Which style should be utilized for the documenation, `gaudi` or `Gaudi`. I'd then adjust the pull request if needed.